### PR TITLE
fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Other calls can create additional documents for the same collection.
 
 Here are some resources that walk you through working with MarkLogic using the Node.js API:
 
-* http://developer.marklogic.com/features/node-api
+* http://developer.marklogic.com/features/node-client-api
 * http://docs.marklogic.com/guide/node-dev/intro#id_68052
 
 The instructions describe:


### PR DESCRIPTION
The README had the wrong link for /features/node-client-api