### PR TITLE
handle sparqlUpdate request as single string arg

### DIFF
--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -787,8 +787,10 @@ Graphs.prototype.sparqlUpdate = function updateGraphSPARQL() {
     defaultRulesets    = arg.defaultRulesets;
     optimizeLevel      = arg.optimizeLevel;
     bindings           = arg.bindings;
-  } else {
-    data = args[1];
+  }
+  // SPARQL request is single string argument
+  else {
+    data = args[0];
   }
 
   var endpoint = '/v1/graphs/sparql';


### PR DESCRIPTION
This bug fix supports the shortcut way of calling graph.sparqlUpdate(). The method can also be called with a configuration object.

closes #236