### PR TITLE
remove unnecessary code in requester.js

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -159,30 +159,24 @@ function authenticatedRequest(operation, authenticator, requester) {
   } else {
     requester.call(operation, request);
   }
-  return request;
 }
 
 function singleRequester(request) {
   /*jshint validthis:true */
   var operation = this;
 
-  var requestBodyProvider = operation.requestBodyProvider;
-  if (typeof requestBodyProvider === 'function') {
-    requestBodyProvider.call(operation, request);
+  var requestSource = mlutil.marshal(operation.requestBody);
+  if (requestSource == null) {
+    request.end();
+  } else if (typeof requestSource === 'string' || requestSource instanceof String) {
+    request.write(requestSource, 'utf8');
+    request.end();
+  // readable stream might not inherit from ReadableStream
+  } else if (typeof requestSource._read === 'function') {
+    requestSource.pipe(request);
   } else {
-    var requestSource = mlutil.marshal(operation.requestBody);
-    if (requestSource == null) {
-      request.end();
-    } else if (typeof requestSource === 'string' || requestSource instanceof String) {
-      request.write(requestSource, 'utf8');
-      request.end();
-    // readable stream might not inherit from ReadableStream
-    } else if (typeof requestSource._read === 'function') {
-      requestSource.pipe(request);
-    } else {
-      request.write(requestSource);
-      request.end();
-    }
+    request.write(requestSource);
+    request.end();
   }
 }
 function multipartRequester(request) {


### PR DESCRIPTION
authenticatedRequest() is called twice, and neither call uses a return value, so safe to remove "return request".

operation.requestBodyProvider property is never set, so safe to remove the logic that acts on it.