### PR TITLE
Check if documents property is undefined for a resource PUT or POST

### DIFF
--- a/lib/resources-exec.js
+++ b/lib/resources-exec.js
@@ -22,7 +22,7 @@ var Operation = require('./operation.js');
  * Provides functions to execute resource services on the REST server
  * for the client. The resource service extensions must have been
  * installed previously on the REST server using the
- * {@link config.resources#write} function. 
+ * {@link config.resources#write} function.
  * @namespace resources
  */
 
@@ -229,8 +229,10 @@ function writeResources(self, method, responseType, args) {
     };
 
   var partList = [];
-  for (var i=0; i < documents.length; i++) {
-    addPart(partList, documents[i]);
+  if (typeof documents !== 'undefined') {
+    for (var i=0; i < documents.length; i++) {
+      addPart(partList, documents[i]);
+    }
   }
 
   var operation = new Operation(
@@ -271,7 +273,7 @@ function addPart(partList, document) {
     headers['Content-Type'] = 'text/plain';
   } else if (Buffer.isBuffer(document)) {
     part.content = document;
-    headers['Content-Type'] = 'application/x-unknown-content-type';      
+    headers['Content-Type'] = 'application/x-unknown-content-type';
   } else {
     part.content = JSON.stringify(document);
 //    headers['Content-Type'] = 'application/json; charset=utf-8';


### PR DESCRIPTION
Allows cases where the documents property is not defined.

Fixes #257