### PR TITLE
Handle metadataValues category for documents.patch().

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1668,8 +1668,13 @@ Documents.prototype.patch = function patchDocuments() {
   var endpoint = '/v1/documents?uri='+encodeURIComponent(uri);
   if (categories != null) {
     if (!Array.isArray(categories)) {
-      endpoint += '&category=' + categories;
-    } else if (categories.length > 0) {
+      categories = [categories];
+    }
+    var i = 0;
+    for (i = 0; i < categories.length; i++) {
+      categories[i] = categories[i] === 'metadataValues' ? 'metadata-values' : categories[i];
+    }
+    if (categories.length > 0) {
       endpoint += '&category=' + categories.join('&category=');
     }
   }


### PR DESCRIPTION
Fixes #279 