### PR TITLE
Allow custom http(s) agent to be used

### DIFF
--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -621,10 +621,16 @@ function initClient(client, inputParams) {
       });
       connectionParams.agent = new YAgent.SSL(agentOptions);
     }
+    else {
+      connectionParams.agent = inputParams.agent;
+    }
   } else {
     client.request = http.request;
     if (noAgent) {
       connectionParams.agent = new YAgent(agentOptions);
+    }
+    else {
+      connectionParams.agent = inputParams.agent;
     }
   }
 }  

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -620,16 +620,14 @@ function initClient(client, inputParams) {
         }
       });
       connectionParams.agent = new YAgent.SSL(agentOptions);
-    }
-    else {
+    } else {
       connectionParams.agent = inputParams.agent;
     }
   } else {
     client.request = http.request;
     if (noAgent) {
       connectionParams.agent = new YAgent(agentOptions);
-    }
-    else {
+    } else {
       connectionParams.agent = inputParams.agent;
     }
   }

--- a/test-basic/client.js
+++ b/test-basic/client.js
@@ -21,6 +21,8 @@ var testconfig = require('../etc/test-config.js');
 var marklogic = require('../');
 var q = marklogic.queryBuilder;
 
+var YAgent = require('yakaa');
+
 // TODO: setup should create user with eval-in role
 var connection = {
     user:     'admin',
@@ -43,7 +45,17 @@ Object.keys(connection).forEach(function(key){
   }
 });
 var otherDb = marklogic.createDatabaseClient(otherConnection);
-    
+
+var agentConnection = {
+  agent: new YAgent({keepAlive: true, keepAliveTimeoutMsecs: 1000})
+}
+Object.keys(otherConnection).forEach(function(key){
+  if (agentConnection[key] === undefined) {
+    agentConnection[key] = otherConnection[key];
+  }
+});
+var agentDb = marklogic.createDatabaseClient(agentConnection);
+
 describe('database clients', function() {
   it('should write in a default db and read in a specified db', function(done) {
     db.documents.write({
@@ -80,5 +92,13 @@ describe('database clients', function() {
       done();
       })
     .catch(done);
+  });
+  it('should use a default agent', function(done) {
+    otherDb.connectionParams.agent.options.keepAlive.should.equal(true);
+    done();
+  });
+  it('should use a custom agent', function(done) {
+    agentDb.connectionParams.agent.options.keepAliveTimeoutMsecs.should.equal(1000);
+    done();
   });
 });


### PR DESCRIPTION
Currently a default http(s) agent is provided via Yakaa if the `agent` configuration option is not set. If it is set though the agent is completely omitted from the `connectionParams` object. This change will maintain existing behavior of providing a default agent but also allows users to specify one of their own.
