### PR TITLE
Use var instead of const in variable declaration

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -26,7 +26,7 @@ function library(libname) {
   }
 }
 function libraryProperty(libname, propertyName) {
-  const lib = library(libname);
+  var lib = library(libname);
   if (lib == null) {
     return null;
   }


### PR DESCRIPTION
ES6 features cause issues with earlier versions of Node.js.