### PR TITLE
Remove gulp-jsdoc dep from package.json until taffydb issue is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "bunyan": "^1.3.3",
     "core-util-is": "^1.0.1",
     "gulp": "^3.8.10",
-    "gulp-jsdoc": "^0.1.4",
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
     "jsdoc": "^3.3.0-beta1",


### PR DESCRIPTION
A renaming has broken apps that depend on gulp-jsdoc:
https://github.com/hegemonic/taffydb/pull/1