### PR TITLE
Use npm-shrinkwrap to work around gulp-jsdoc issue

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "gulp-jsdoc": {
+      "version": "0.1.5",
+      "from": "gulp-jsdoc@0.1.5",
+      "dependencies": {
+        "taffydb": {
+          "version": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bunyan": "^1.3.3",
     "core-util-is": "^1.0.1",
     "gulp": "^3.8.10",
+    "gulp-jsdoc": "^0.1.4",
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
     "jsdoc": "^3.3.0-beta1",


### PR DESCRIPTION
Similar to what jsdoc is doing:
https://github.com/jsdoc3/jsdoc/commit/de87a1b3f49bd360c5ef10c9edc7bd12bd8e96df