### PR TITLE
Prevent premature socket destruction

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -126,7 +126,6 @@ function challengeRequest(operation, requester) {
       var authenticator = (hasChallenge) ? createAuthenticator(
           operation.client, options.user, options.password, challenge
           ) : null;
-      response1.destroy();
       authenticatedRequest(operation, authenticator, requester);
     // should never happen
     } else if (successStatus && isRead) {

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -32,7 +32,6 @@ function responseDispatcher(response) {
 
   var outputMode = operation.outputMode;
   if (outputMode === 'none') {
-    response.destroy();
     return;
   }
 
@@ -83,7 +82,6 @@ function responseDispatcher(response) {
   if (isEmpty) {
     if (expectedType !== 'empty') {
       operation.logger.debug('expected body or multipart but received empty response');
-      response.destroy();
     }
 
     if (outputMode === 'promise') {
@@ -778,7 +776,6 @@ function isResponseStatusOkay(response) {
           }));
     } else {
       operation.errorListener(clientError);
-      response.destroy();
     }
 
     return false;

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -83,9 +83,8 @@ function responseDispatcher(response) {
   if (isEmpty) {
     if (expectedType !== 'empty') {
       operation.logger.debug('expected body or multipart but received empty response');
+      response.destroy();
     }
-
-    response.destroy();
 
     if (outputMode === 'promise') {
       dispatcher.emptyPromise(response);


### PR DESCRIPTION
Calling `response.destroy()` on an empty response leads to the underlaying socket to be closed. This is probably desirable in an error case, but if the response is expected to be empty it results in socket closures even when socket pooling is enabled.
## Steps to reproduce
1. Configure MarkLogic to use a connection pool, e.g.
   
   ``` javascript
   const marklogic = require('marklogic');
   const Agent = require('yakaa');
   
   const agent = new Agent({
   kepAlive: true,
   keepAliveMsecs: 1000,
   keepAliveTimeoutMsecs: 15000,
   maxSockets: 42,
   maxFreeSockets: 10,
   });
   
   const db = marklogic.createDatabase({
   agent,
   host: 'ml.example.com',
   port: 9999,
   user: 'sample_user',
   password: 'sample_password'
   });
   ```
2. Issue a call to MarkLogic that results in an expected empty response – specifically I observed this when saving documents with a given URI that did not already exist in the database
   
   ``` javascript
   db.documents.write([
   {
     uri: 'http://data/ns.org.com/entityType/new-entity-id.json',
     content: {
       // ...
     }
   }
   ])
   .result()
   ```
3. Observe that a `PUT` is issued to the server with an empty response

The last observation _may_ be a result of the way the MarkLogic instance I'm querying is configured, but regardless, the empty response causing the socket to be destroyed nullifies all benefits of connection pooling.
