### PR TITLE
Refactor near() to use NearDef()

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -1926,6 +1926,14 @@ function near() {
   if (args.length < 1) {
     throw new Error('need at least a subquery for near query');
   }
+  return new NearDef(args);
+}
+/** @ignore */
+function NearDef(args) {
+  if (!(this instanceof NearDef)) {
+    return new NearDef(args);
+  }
+
   var query               = {};
   var subquery            = [];
   var seekingOrdered      = true;
@@ -1970,8 +1978,10 @@ function near() {
 
   query.queries = checkQueryArray(subquery);
 
-  return {'near-query': query};
+  this['near-query'] = query;
+
 }
+util.inherits(NearDef, QueryDef);
 /**
  * Builds a query that removes any documents matched by the subquery.
  * @method


### PR DESCRIPTION
NearDef() inherits from QueryDef()

Fixes #316