### PR TITLE
Open Issue #255

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -167,11 +167,20 @@ Documents.prototype.probe = function probeDocument() {
 };
 function probeDocumentsImpl(contentOnly, args) {
   /*jshint validthis:true */
-  if (args.length !== 1) {
+  if (args.length !== 1 && args.length !== 2) {
     throw new Error('must supply uri for document check()');
   }
 
-  var params = ((typeof args[0] !== 'string' && !(args[0] instanceof String))) ? args[0] : null; 
+  var params;
+  if (args.length === 1 && typeof args[0] !== 'string' && !(args[0] instanceof String)) {
+    params = args[0];
+  }
+  else if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
+    params = {uri: args[0], txid: args[1]};
+  }
+  else {
+    params = null;
+  }
 
   var uri = null;
   var txid = null;


### PR DESCRIPTION
Fixes issue #255: db.documents.probe() throws error when transaction Id is passed as second param