### PR TITLE
update docs for near() requirements

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -1908,6 +1908,10 @@ function MinDistanceDef(distance) {
 }
 /**
  * Builds a query that matches the subqueries within a specified proximity.
+ * Note that you may get false positives from a near query if you do not have
+ * the appropriate position index enabled or run the query unfiltered (which
+ * is the default). While turning on filtering can be convenient during
+ * development, setting up indexes is recommended for production.
  * @method
  * @memberof queryBuilder#
  * @param {...queryBuilder.Query} subquery - a word, value, range, geospatial,


### PR DESCRIPTION
To avoid false positives, you can turn on the word positions index or enable filtering