### PR TITLE
fix(#231): address deprecated features

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1368,12 +1368,10 @@ function removeOutputTransform(headers/*, data*/) {
   var operation = this;
 
   if (operation.contentOnly === true) {
-    // for deprecated backward compatibility
-    return operation.isLegacy ? operation.uris[0] : operation.uris;
+    return operation.uris;
   }
 
   var wrapper = {
-    uri:     operation.uris[0], // for deprecated backward compatibility
     uris:    operation.uris,
     removed: true
   };
@@ -1414,10 +1412,10 @@ function removeOutputTransform(headers/*, data*/) {
  */
 Documents.prototype.remove = function removeDocument() {
   return removeDocumentImpl.call(
-      this, false, false, mlutil.asArray.apply(null, arguments)
+      this, false, mlutil.asArray.apply(null, arguments)
       );
 };
-function removeDocumentImpl(contentOnly, isLegacy, args) {
+function removeDocumentImpl(contentOnly, args) {
   /*jshint validthis:true */
   if (args.length < 1) {
     throw new Error('must provide uris for document remove()');
@@ -1436,13 +1434,8 @@ function removeDocumentImpl(contentOnly, isLegacy, args) {
     uris = args;
   } else {
     uris = arg.uris;
-    // for deprecated backward compatibility
     if (uris == null) {
-      uris = arg.uri;
-
-      if (uris == null) {
-        throw new Error('must specify the uris parameters with at least one document to remove');
-      }
+      throw new Error('must specify the uris parameters with at least one document to remove');
     }
     if (!Array.isArray(uris)) {
       uris = [uris];
@@ -1487,7 +1480,6 @@ function removeDocumentImpl(contentOnly, isLegacy, args) {
   operation.outputTransform  = removeOutputTransform;
   operation.errorTransform   = uriErrorTransform;
   operation.contentOnly      = (contentOnly === true);
-  operation.isLegacy         = isLegacy;
 
   return requester.startRequest(operation);
 }

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -445,16 +445,13 @@ MarkLogicClient.prototype.read = function readClient() {
  * @param {string|string[]}  uris - the uri string or an array of uri strings
  * identifying the database documents
  * @returns {ResultProvider} an object whose result() function takes
- * a success callback that receives the uris identifying the removed documents.
- * For backward compatibility, if a string ispassed, the uri is returned
- * as a string, but in the next major release, the uri will be return
- * as an array with one string.
+ * a success callback that receives an array of the uris identifying
+ * the removed documents.
  */
 MarkLogicClient.prototype.remove = function removeClient() {
   return documents.removeImpl.call(
       this.documents,
       true,
-      (arguments.length === 1 && (typeof arguments[0] === 'string' || arguments[0] instanceof String)),
       mlutil.asArray.apply(null, arguments)
       );
 };

--- a/lib/mlutil.js
+++ b/lib/mlutil.js
@@ -309,7 +309,8 @@ function addTxidHeaders(requestOptions, txid) {
   }
 }
 
-var sliceMode = 'legacy';
+// Slice mode can be 'array' or 'legacy'
+var sliceMode = 'array';
 function setSliceMode(mode) {
   sliceMode = mode;
 }

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -3766,18 +3766,19 @@ function transform(name, params) {
  * from the result set based on the start document within the result set
  * and the number of documents in the slice.  (A slice is also sometimes
  * called a page of search results.)
- * By default, the slice uses legacy slice mode, but you can switch
- * to array slice mode with {@link module:marklogic.setSliceMode}
+ * By default, the slice uses array slice mode, but you can switch
+ * to legacy slice mode with {@link module:marklogic.setSliceMode}. Legacy
+ * slice mode is deprecated and will be removed in the next major release.
  * @method
  * @memberof queryBuilder#
- * @param {number} start - in legacy slice mode, the one-based position
- * within the result set of the first document or 0 to suppress the documents
- * and return only the summary; in array slice mode, the zero-based position
- * within the result set of the first document
- * @param {number} [length] - in legacy slice mode, the number of documents
- * in the slice; in array slice mode, the zero-based position of the document
- * after the last document in the slice or 0 to suppress the documents and
- * return only the summary
+ * @param {number} start - in array slice mode, the zero-based position
+ * within the result set of the first document; in legacy slice mode, the
+ * one-based position within the result set of the first document or 0 to
+ * suppress the documents and return only the summary
+ * @param {number} [length] - in array slice mode, the zero-based position
+ * of the document after the last document in the slice or 0 to suppress
+ * the documents and return only the summary; in legacy slice mode, the
+ * number of documents in the slice
  * @param {transform} [transform] - a transform to apply to each document
  * in the slice on the server as specified by the {@link queryBuilder#transform}
  * function.

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -60,12 +60,11 @@ function Transactions(client) {
  * @param {number}  [timeLimit] - the maximum number of seconds that
  * the transaction should run before rolling back automatically
  * @param {boolean}  [withState] - whether to return a Transaction
- * object that can track the properties of the transaction 
- * @returns {string|transactions.Transaction} either a string
- * transactionId (the default) or a Transaction object identifying
- * the multi-statement transaction; in the next major release,
- * the Transaction object will become the default and the string
- * transactionId will be deprecated. 
+ * object that can track the properties of the transaction
+ * @returns {transactions.Transaction|string} either a Transaction object
+ * (the default) or string transactionId identifying the multi-statement
+ * transaction; returning a string transactionId is deprecated and
+ * will be removed in the next major release.
  */
 Transactions.prototype.open = function openTransaction() {
   var args   = mlutil.asArray.apply(null, arguments);
@@ -119,7 +118,7 @@ Transactions.prototype.open = function openTransaction() {
       );
   operation.validStatusCodes = [303];
   operation.outputTransform  = openOutputTransform;
-  operation.withState        = withState || false;
+  operation.withState        = withState || true;
 
   return requester.startRequest(operation);
 };

--- a/test-basic/documents-query.js
+++ b/test-basic/documents-query.js
@@ -213,7 +213,7 @@ describe('document query', function(){
         calculate(
             q.facet('rangeKey1'),
             q.facet('rangeKey2')).
-        slice(0)
+        slice(0, 0)
         )
       .result(function(response) {
         response.length.should.equal(1);
@@ -272,7 +272,7 @@ describe('document query', function(){
                 q.heatmap(3, 3, q.southWestNorthEast(10, 10, 60, 60))
                 )
             )
-        .slice(0)
+        .slice(0, 0)
         )
       .result(function(response) {
         response.length.should.equal(1);
@@ -382,7 +382,7 @@ describe('document query', function(){
         q.where(
             q.word('scoreKey', 'matchList')
           ).
-        slice(2, 3)
+        slice(1, 4)
         )
       .result(function(response) {
         response.length.should.equal(3);
@@ -402,7 +402,7 @@ describe('document query', function(){
         q.where(
             q.word('scoreKey', 'matchList')
           ).
-        slice(3)
+        slice(2)
         )
       .result(function(response) {
         response.length.should.equal(2);
@@ -422,7 +422,7 @@ describe('document query', function(){
         q.where(
             q.word('wordKey', 'matchWord1')
           ).
-        slice(1, 1, q.extract({
+        slice(0, 1, q.extract({
           selected:'include-with-ancestors',
           paths:'/node("a1")/node("a2")/node("extractMatch")'
           }))
@@ -445,7 +445,7 @@ describe('document query', function(){
         q.where(
             q.word('wordKey', 'matchWord1')
           ).
-        slice(1, 1, q.snippet()).
+        slice(0, 1, q.snippet()).
         withOptions({categories: 'none'})
         )
       .result(function(response) {
@@ -466,7 +466,7 @@ describe('document query', function(){
         q.where(
             q.word('wordKey', 'matchWord1')
           ).
-        slice(1, 1, q.snippet('extractFirst.xqy'))
+        slice(0, 1, q.snippet('extractFirst.xqy'))
         )
       .result(function(response) {
         response.length.should.equal(2);

--- a/test-basic/documents-quick.js
+++ b/test-basic/documents-quick.js
@@ -133,8 +133,9 @@ describe('quick path', function(){
   it('should remove a document', function(done) {
     var docUri = '/test/quick/object1.json';
     db.remove(docUri)
-    .result(function(uri) {
-      docUri.should.eql(uri);
+    .result(function(response) {
+      response.should.be.an.Array;
+      response.length.should.equal(1);
       return db.probe(docUri).result();
       })
     .then(function(exists) {

--- a/test-basic/documents-transform.js
+++ b/test-basic/documents-transform.js
@@ -129,7 +129,7 @@ describe('document transform', function(){
           q.where(
             q.document(uri)
             ).
-          slice(1, 10,
+          slice(0, 10,
             q.transform(xqyTransformName, {flag:'tested3'})
             )
           )
@@ -197,7 +197,7 @@ describe('document transform', function(){
           q.where(
             q.document(readUri)
             ).
-          slice(1, 10,
+          slice(0, 10,
             q.transform(jsTransformName)
             )
           )

--- a/test-basic/extlibs.js
+++ b/test-basic/extlibs.js
@@ -145,7 +145,7 @@ describe('extension libraries', function(){
           calculate(
               q.facet('directories', q.calculateFunction('directoryConstraint.xqy'))
               ).
-          slice(0)
+          slice(0, 0)
           )
         .result(function(response) {
           response.length.should.equal(1);
@@ -171,7 +171,7 @@ describe('extension libraries', function(){
               q.facet('range', 'rangeKey1', q.facetOptions('item-frequency')),
               q.facet('dirs', q.calculateFunction('directoryConstraint.xqy'))
               ).
-          slice(0)
+          slice(0, 0)
           )
         .result(function(response) {
           response.length.should.equal(1);

--- a/test-basic/query-builder.js
+++ b/test-basic/query-builder.js
@@ -2107,31 +2107,32 @@ describe('document query', function(){
       built.orderByClause['sort-order'][0].direction.should.equal('descending');
     });
     it('should build a slice clause with legacy start page and page length', function(){
+      mlutil.setSliceMode('legacy');
       var built = qlib.slice(11, 10);
+      console.log(built);
       built.should.have.property('sliceClause');
       built.sliceClause['page-start'].should.equal(11);
       built.sliceClause['page-length'].should.equal(10);
+      mlutil.setSliceMode('array');
     });
     it('should build a slice clause with array begin and end', function(){
-      mlutil.setSliceMode('array');
       var built = qlib.slice(10, 20);
       built.should.have.property('sliceClause');
       built.sliceClause['page-start'].should.equal(11);
       built.sliceClause['page-length'].should.equal(10);
-      mlutil.setSliceMode('legacy');
     });
     it('should build a slice clause with start page', function(){
-      var built = qlib.slice(11);
+      var built = qlib.slice(10);
       built.should.have.property('sliceClause');
       built.sliceClause['page-start'].should.equal(11);
     });
     it('should build a slice clause without a page', function(){
-      var built = qlib.slice(0);
+      var built = qlib.slice(0, 0);
       built.should.have.property('sliceClause');
       built.sliceClause['page-length'].should.equal(0);
     });
     it('should build a slice clause with a page and a snippet transform', function(){
-      var built = qlib.slice(11, 10,
+      var built = qlib.slice(10, 20,
         q.snippet('foo.xqy', {
           'max-matches': 5,
           'bar':         'baz'
@@ -2167,7 +2168,7 @@ describe('document query', function(){
           q.facet('key2')
       ).orderBy(
           'key3'
-      ).slice(11, 10);
+      ).slice(10, 20);
       built.should.have.property('whereClause');
       built.whereClause.should.have.property('query');
       built.whereClause.query.should.have.property('queries');
@@ -2192,7 +2193,7 @@ describe('document query', function(){
       );
       var marshalled = JSON.stringify(seed);
       var unmarshalled = JSON.parse(marshalled);
-      var built = q.copyFrom(unmarshalled).slice(11, 10);
+      var built = q.copyFrom(unmarshalled).slice(10, 20);
       built.should.have.property('whereClause');
       built.whereClause.should.have.property('query');
       built.whereClause.query.should.have.property('queries');

--- a/test-basic/values-builder.js
+++ b/test-basic/values-builder.js
@@ -143,7 +143,7 @@ describe('values query', function(){
     });
     it('should build a slice clause with start page and page length', function(){
       var built = t.fromIndexes('property1').
-      slice(11, 10);
+      slice(10, 20);
       built.should.have.property('fromIndexesClause');
       built.fromIndexesClause.length.should.equal(1);
       built.fromIndexesClause[0].should.have.property('range');
@@ -155,7 +155,7 @@ describe('values query', function(){
     });
     it('should build a slice clause with start page', function(){
       var built = t.fromIndexes('property1').
-      slice(11);
+      slice(10);
       built.should.have.property('fromIndexesClause');
       built.fromIndexesClause.length.should.equal(1);
       built.fromIndexesClause[0].should.have.property('range');

--- a/test-basic/values.js
+++ b/test-basic/values.js
@@ -199,7 +199,7 @@ describe('values query', function(){
         where(
           t.collection('valuesCollection1')
           ).
-        slice(2, 3)
+        slice(1, 4)
         )
       .result(function(values) {
         values.should.have.property('values-response');
@@ -224,7 +224,7 @@ describe('values query', function(){
         where(
           t.collection('valuesCollection1')
           ).
-        slice(0).
+        slice(0, 0).
         aggregates('correlation', 'covariance')
         )
       .result(function(values) {
@@ -248,7 +248,7 @@ describe('values query', function(){
         where(
           t.collection('valuesCollection1')
           ).
-        slice(2, 3).
+        slice(1, 4).
         withOptions({values:['descending']})
         )
       .result(function(values) {


### PR DESCRIPTION
- legacy non-array return values for remove() methods
- default return values for transactions.open() (change from transaction ID to object)
- default slice mode (change from "legacy" to "array")