### PR TITLE
Fix issues in jsdoc generation

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,21 +1,22 @@
 {
   "opts": {
-    "destination":         "./doc",
-    "template":            "./etc/marklogic-template"
+    "destination":          "./doc",
+    "template":             "./etc/marklogic-template"
   },
   "templates": {
-    "theme":               "marklogic",
-    "systemName":          "MarkLogic Node.js Client API",
-    "copyright":           "Copyright 2014-2017 MarkLogic Corporation",
-    "navType":             "vertical",
-    "inverseNav":          true,
-    "includeDate":         false,
-    "cleverLinks":         false,
-    "monospaceLinks":      false,
-    "linenums":            true,
-    "search":              false,
-    "sort":                true,
-    "outputSourceFiles":   false,
-    "outputSourcePath":    false
+    "theme":                "marklogic",
+    "systemName":           "MarkLogic Node.js Client API",
+    "copyright":            "Copyright 2014-2017 MarkLogic Corporation",
+    "navType":              "vertical",
+    "inverseNav":           true,
+    "includeDate":          false,
+    "cleverLinks":          false,
+    "monospaceLinks":       false,
+    "linenums":             true,
+    "search":               false,
+    "sort":                 true,
+    "outputSourceFiles":    false,
+    "outputSourcePath":     false,
+    "methodHeadingReturns": true
   }
 }

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -39,7 +39,7 @@ var valuesBuilder        = require('./values-builder.js');
 /**
  * Provides functions to connect to a MarkLogic database and to build
  * requests for the database.
- * @module marklogic
+ * @namespace marklogic
  */
 
 /**
@@ -205,7 +205,7 @@ function expandExtlibsWrapper(action, args) {
 /**
  * A client object configured to write, read, query, and perform other
  * operations on a database as a user. The client object is
- * created by the {@link module:marklogic.createDatabaseClient} function.
+ * created by the {@link marklogic.createDatabaseClient} function.
  * @namespace DatabaseClient
  * @borrows serverExec#eval       as DatabaseClient#eval
  * @borrows serverExec#xqueryEval as DatabaseClient#xqueryEval
@@ -216,7 +216,7 @@ function expandExtlibsWrapper(action, args) {
  * Creates a database client to make database requests such as writes, reads,
  * and queries. The constructor takes a configuration object with the following
  * named parameters.
- * @function module:marklogic.createDatabaseClient
+ * @function marklogic.createDatabaseClient
  * @param {string} [host=localhost] - the host with the REST server for the database
  * @param {number} [port=8000] - the port with the REST server for the database
  * @param {string} [database] - the name of the database to access, defaulting
@@ -659,19 +659,19 @@ module.exports = {
     createDatabaseClient: MarkLogicClient,
     /**
      * A factory for creating a document query builder.
-     * @function
+     * @function marklogic.queryBuilder
      * @returns {queryBuilder} a helper for defining a document query
      */
     queryBuilder:  queryBuilder.builder,
     /**
      * A factory for creating a document patch builder
-     * @function
+     * @function marklogic.patchBuilder
      * @returns {patchBuilder} a helper for defining a document patch
      */
     patchBuilder:  patchBuilder,
     /**
      * A factory for creating a values builder
-     * @function
+     * @function marklogic.valuesBuilder
      * @returns {valuesBuilder} a helper for defining a query
      * to project tuples (rows) of values from documents
      */
@@ -683,7 +683,7 @@ module.exports = {
      * zero-based or legacy slice(pageStart, pageLength) where pageStart
      * is one-based. The default is array slice mode. Legacy slice mode
      * is deprecated and will be removed in the next major release.
-     * @function
+     * @function marklogic.setSliceMode
      * @param {string} mode - "array" or "legacy"
      */
     setSliceMode:  setSliceMode


### PR DESCRIPTION
Add methodHeadingReturns option for jsdoc to display return values with methods.
Tag marklogic as a namespace instead of module to address the fact that, with marklogic as a module, jsdoc is not recognizing methods of marklogic such as createDatabaseClient(). Fixes #372.
