### PR TITLE
Extend timeout for suggest test

### DIFF
--- a/test-basic/suggest.js
+++ b/test-basic/suggest.js
@@ -59,6 +59,7 @@ describe('suggest', function() {
     .catch(done);
   });
   it('should handle default criteria', function(done) {
+    this.timeout(3000);
     db.documents.suggest(
         'aSuggest',
         q.where(


### PR DESCRIPTION
Test often fails due to timeout, extend from default 2000 ms to 3000 ms.