### PR TITLE
Handle removing nonexistent document

### DIFF
--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1381,13 +1381,15 @@ function removeOutputTransform(headers/*, data*/) {
   /*jshint validthis:true */
   var operation = this;
 
+  var removed = (operation.responseStatusCode === 204) ? true : false;
+
   if (operation.contentOnly === true) {
     return operation.uris;
   }
 
   var wrapper = {
     uris:    operation.uris,
-    removed: true
+    removed: removed
   };
 
   var systemTime = headers.systemTime;
@@ -1476,6 +1478,7 @@ function removeDocumentImpl(contentOnly, args) {
       path += '&system-time='+systemTime.toISOString();
     }
   }
+  path += '&check=exists'; // Returns 204 if removed, 404 if not found
 
   var connectionParams = this.client.connectionParams;
   var requestOptions = mlutil.copyProperties(connectionParams);
@@ -1492,7 +1495,7 @@ function removeDocumentImpl(contentOnly, args) {
       'remove document', this.client, requestOptions, 'empty', 'empty'
       );
   operation.uris             = uris;
-  operation.validStatusCodes = [204];
+  operation.validStatusCodes = [204, 404];
   operation.outputTransform  = removeOutputTransform;
   operation.errorTransform   = uriErrorTransform;
   operation.contentOnly      = (contentOnly === true);

--- a/test-basic/documents-core.js
+++ b/test-basic/documents-core.js
@@ -414,7 +414,7 @@ describe('document content', function(){
           .result(function(response){done();})
           .catch(done);
         });
-        it('should not exist', function(done){
+        it('should be removed and no longer exist', function(done){
           db.documents.remove(
               '/test/remove/doc1.json',
               '/test/remove/doc2.json'
@@ -422,12 +422,25 @@ describe('document content', function(){
             .result(function(response) {
               response.should.have.property('uris');
               response.uris.length.should.equal(2);
+              response.removed.should.equal(true);
               return db.documents.probe(response.uris[0]).result();
               })
             .then(function(document) {
               valcheck.isUndefined(document).should.equal(false);
               document.should.have.property('exists');
               document.exists.should.eql(false);
+              done();
+              })
+            .catch(done);
+        });
+      });
+      describe('a nonexistent document', function(){
+        it('should not be removed', function(done){
+          db.documents.remove('/test/remove/noExist.json')
+            .result(function(response) {
+              response.should.have.property('uris');
+              response.uris.length.should.equal(1);
+              response.removed.should.equal(false);
               done();
               })
             .catch(done);


### PR DESCRIPTION
The REST API now supports a "check=exists" parameter for document deletes.
Use this to recognize when a document being removed does not exist and return
"removed: false" in the response payload. Fixes #407