### PR TITLE
Refactor promise and object stream dispatches

### DIFF
--- a/lib/operation.js
+++ b/lib/operation.js
@@ -45,6 +45,7 @@ function Operation(name, client, options, requestType, responseType) {
   this.outputStreamMode   = null;
   this.outputStream       = null;
   this.streamModes        = this.STREAM_MODES_CHUNKED_OBJECT;
+  this.nextMetadataBuffer = null;
 }
 Operation.prototype.STREAM_MODES_CHUNKED_OBJECT = {chunked: true, object: true};
 
@@ -90,17 +91,23 @@ Operation.prototype.collectBodyObject = function collectBodyObject(data) {
 
   return bodyObject;
 };
-Operation.prototype.queueDocument = function queueDocument(
-    data, rawHeaderQueue, metadataBuffer, objectQueue
+/**
+ * Make an object out of multipart part data
+ * @param {Buffer} data - Multipart part data
+ * @param {FifoQueue} rawHeaderQueue - Queue of headers for part data
+ * @return {Object} - The object
+ */
+Operation.prototype.makeObject = function makeObject(
+    data, rawHeaderQueue
     ) {
   var operation = this;
 
   var outputTransform = operation.outputTransform;
+  var partObject = null;
 
+  // Get corresponding multipart header for part
   var partRawHeaders = rawHeaderQueue.pollFirst();
-
   var partHeaders = parsePartHeaders(partRawHeaders);
-
   var partUri = partHeaders.uri;
 
   var isInline = (partUri == null);
@@ -110,66 +117,60 @@ Operation.prototype.queueDocument = function queueDocument(
       partHeaders.category !== 'content'
     );
 
+  // Convert buffer data to object
   var partData = mlutil.unmarshal(partHeaders.format, data);
 
-  var nextMetadataBuffer = null;
-  var partObject         = null;
+  // Inline case
   if (isInline) {
-    if (metadataBuffer !== null) {
-      operation.queueMetadata(metadataBuffer, objectQueue);
-    }
     operation.logger.debug('parsed inline');
+    // Resource execs and server-side evals
     if (operation.inlineAsDocument) {
       partHeaders.content = partData;
       partObject = partHeaders;
-    } else {
+    }
+    // Search summaries
+    else {
       partObject = partData;
     }
-  } else if (isMetadata) {
-    if (metadataBuffer !== null) {
-      operation.queueMetadata(metadataBuffer, objectQueue);
-    }
+  }
+  // Metadata case
+  else if (isMetadata) {
     operation.logger.debug('parsed metadata for %s', partUri);
-    nextMetadataBuffer = [partHeaders, partData];
-  } else {
+    if (this.nextMetadataBuffer !== null) {
+      var metadataHeaders = this.nextMetadataBuffer[0];
+      mlutil.copyProperties(this.nextMetadataBuffer[1], metadataHeaders);
+      partObject = metadataHeaders;
+    }
+    this.nextMetadataBuffer = [partHeaders, partData];
+  }
+  // Content case
+  else {
     operation.logger.debug('parsed content for %s', partUri);
-    if (metadataBuffer !== null) {
-      if (metadataBuffer[0].uri === partUri) {
-        operation.logger.debug('copying metadata for %s', partUri);
-        mlutil.copyProperties(metadataBuffer[1], partHeaders);
-      } else {
-        operation.queueMetadata(metadataBuffer, objectQueue);
-      }
+    // If metadata exists, copy to object
+    if (this.nextMetadataBuffer !== null) {
+      operation.logger.debug('copying metadata for %s', partUri);
+      mlutil.copyProperties(this.nextMetadataBuffer[1], partHeaders);
+      this.nextMetadataBuffer = null;
     }
     partHeaders.content = partData;
     partObject = partHeaders;
   }
 
   if (partObject !== null) {
+    // Subdata processing (poor man's XPath)
     var subdata = operation.subdata;
     if (Array.isArray(subdata)) {
       partObject = projectData(partObject, subdata, 0);
     }
-
+    // Transform
     if (outputTransform != null) {
       partObject = outputTransform.call(operation, partRawHeaders, partObject);
     }
-
-    if (partObject !== void 0) {
-      objectQueue.addLast(partObject);
-    } else {
+    if (partObject === void 0) {
       operation.logger.debug('skipped undefined output from transform');
     }
   }
-
-  return nextMetadataBuffer;
-};
-Operation.prototype.queueMetadata = function queueMetadata(
-    metadataBuffer, objectQueue
-    ) {
-  var metadataHeaders = metadataBuffer[0];
-  mlutil.copyProperties(metadataBuffer[1], metadataHeaders);
-  objectQueue.addLast(metadataHeaders);
+  return partObject;
 };
 Operation.prototype.dispatchError = function dispatchError(error) {
   var operation = this;

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -412,8 +412,6 @@ MultipartDispatcher.prototype.chunkedStream = function dispatchMultipartChunkedS
       partReadStream.pipe(outputStream, {end: false});
     } else if (hasParsed) {
       responseFinisher();
-    } else if (!hasEnded) {
-      parser.emit('drain');
     }
   };
 

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -462,6 +462,8 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   var hasParsed = false;
   var hasEnded  = false;
 
+  var isConcatenating = false;
+
   var responseFinisher = function objectResponseFinisher() {
 
     if (!partReaderQueue.hasItem() && hasParsed && hasEnded) {
@@ -511,10 +513,11 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
     }
 
     partReaderQueue.removeFirst();
+    isConcatenating = false;
 
     // If item avail, concat-stream it with callback to finisher
     if (partReaderQueue.hasItem()) {
-
+      isConcatenating = true;
       var partRead = concatStream(partFinisher);
       partRead.on('error', errorListener);
       var partReadStream = partReaderQueue.getFirst();
@@ -540,6 +543,7 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
     partReaderQueue.addLast(partReadStream);
 
     if (partReaderQueue.isLast()) {
+      isConcatenating = true;
       var partRead = concatStream(partFinisher);
       partRead.on('error', errorListener);
       partReadStream.pipe(partRead);
@@ -559,7 +563,8 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   var drainListener = function objectDrainListener() {
     if (!hasEnded) {
       response.resume();
-      if (partReaderQueue.hasItem()) {
+      if (partReaderQueue.hasItem() && !isConcatenating) {
+        isConcatenating = true;
         var partRead = concatStream(partFinisher);
         partRead.on('error', errorListener);
         var partReadStream = partReaderQueue.getFirst();
@@ -630,9 +635,6 @@ FifoQueue.prototype.isLast = function fifoIsLast() {
 FifoQueue.prototype.getFirst = function fifoGetFirst() {
   return (this.first >= 0) ? this.queue[this.first] : undefined;
 };
-FifoQueue.prototype.getLast = function fifoGetLast() {
-  return (this.first >= 0) ? this.queue[this.last] : undefined;
-};
 FifoQueue.prototype.removeFirst = function fifoRemoveFirst() {
   if (this.first >= 0) {
     this.queue[this.first] = undefined;
@@ -656,6 +658,9 @@ FifoQueue.prototype.getQueue = function fifoGetQueue() {
       this.queue : this.queue.slice(this.first, this.last + 1);
 };
 /*
+FifoQueue.prototype.getLast = function fifoGetLast() {
+  return (this.first >= 0) ? this.queue[this.last] : undefined;
+};
 FifoQueue.prototype.getTotal = function fifoGetTotal() {
   return this.total;
 };

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -503,10 +503,10 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
 
     // Manage backpressure
     if (writeResult === false) {
-      // Only pause stream if not all parsed
+      // Only pause resp stream if not all parsed and resp hasn't ended
       if (hasParsed && !partReaderQueue.hasItem()) {
         responseFinisher();
-      } else {
+      } else if (!hasEnded) {
         response.pause();
       }
       return;

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -557,7 +557,15 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   };
 
   var drainListener = function objectDrainListener() {
-    response.resume();
+    if (!hasEnded) {
+      response.resume();
+      if (partReaderQueue.hasItem()) {
+        var partRead = concatStream(partFinisher);
+        partRead.on('error', errorListener);
+        var partReadStream = partReaderQueue.getFirst();
+        partReadStream.pipe(partRead);
+      }
+    }
   };
 
   var parser = new Dicer({boundary: boundary});

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -599,133 +599,6 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
     part end 2
     finish
  */
-// function QueuedReader(options, logger, itemsTransform) {
-//   if (!(this instanceof QueuedReader)) {
-//     return new QueuedReader(options, logger, itemsTransform);
-//   }
-//   stream.Readable.call(this, options);
-
-//   var self = this;
-
-//   this.itemsTransform = itemsTransform;
-//   this.logger         = logger;
-
-//   this.minWriters =  5;
-//   this.maxItems   = 10;
-
-//   this.readerQueue = new FifoQueue(10);
-//   this.writerQueue = new FifoQueue(this.minWriters);
-//   this.itemQueue   = new FifoQueue(this.maxItems);
-
-//   this.isReading = true;
-//   this.queueDone = false;
-
-//   this.addItems = function queuedReaderAddItems(data) {
-//     self.writerQueue.removeFirst();
-
-//     self.logger.debug('concatenated item');
-
-//     var itemQueue    = self.itemQueue;
-//     var beforeLength = itemQueue.length();
-
-//     self.itemsTransform(data);
-
-//     if (beforeLength < itemQueue.length()) {
-//       if (beforeLength === 0) {
-//         self.emit('readable');
-//       }
-//       if (self.isReading || isLast) {
-//         logger.debug('writing first item');
-//         self.isReading = self.push(itemQueue.pollFirst());
-//       }
-//     }
-
-//     self.nextReader();
-//   };
-// }
-// util.inherits(QueuedReader, stream.Readable);
-// QueuedReader.prototype.addReader = function queuedAddReader(reader) {
-//   var readerQueue = this.readerQueue;
-//   if (readerQueue === null) {
-//     return;
-//   }
-
-//   readerQueue.addLast(reader);
-//   this.logger.debug('queued item %d', readerQueue.getTotal());
-//   this.nextReader();
-// };
-// QueuedReader.prototype.getItemQueue = function getItemQueue() {
-//   return this.itemQueue;
-// };
-// QueuedReader.prototype.isQueueEmpty = function isQueueEmpty() {
-//   return (this.readerQueue.length() === 0 && this.writerQueue.length() === 0);
-// };
-// QueuedReader.prototype.nextReader = function queuedReaderNextReader() {
-//   if (!this.isReading) {
-//     return;
-//   }
-
-//   var readerQueue = this.readerQueue;
-//   if (readerQueue === null || readerQueue.length() === 0) {
-//     return;
-//   }
-
-//   if (this.itemQueue.length() >= this.maxItems) {
-//     return;
-//   }
-
-//   var writerQueue = this.writerQueue;
-//   var minWriters  = this.minWriters;
-
-//   var logger = this.logger;
-
-//   var addItems = this.addItems;
-
-//   var i = writerQueue.length();
-//   var j = readerQueue.length();
-//   var writer = null;
-//   for (; i <= minWriters && j > 0; i++, j--) {
-//     writer = concatStream(addItems);
-//     writerQueue.addLast(writer);
-//     logger.debug('reading item');
-//     readerQueue.pollFirst().pipe(writer);
-//   }
-// };
-// QueuedReader.prototype._read = function queuedReaderRead(/*size*/) {
-//   var itemQueue = this.itemQueue;
-//   if (itemQueue === null) {
-//     return;
-//   }
-
-//   var logger = this.logger;
-
-//   var hasItem = itemQueue.hasItem();
-//   var canRead = true;
-//   while (hasItem && canRead) {
-//     logger.debug('writing item');
-//     canRead = this.push(itemQueue.pollFirst());
-//     hasItem = itemQueue.hasItem();
-//   }
-
-//   if (this.queueDone && !hasItem && this.readerQueue.length() === 0 &&
-//       this.writerQueue.length() === 0) {
-//     this.logger.debug('wrote %d items', itemQueue.getTotal());
-//     this.push(null);
-
-//     this.readerQueue = null;
-//     this.writerQueue = null;
-//     this.itemQueue   = null;
-//   } else if (!canRead) {
-//     if (this.isReading) {
-//       this.isReading = false;
-//     }
-//   } else {
-//     if (!this.isReading) {
-//       this.isReading = true;
-//     }
-//     this.nextReader();
-//   }
-// };
 
 function FifoQueue(min) {
   if (!(this instanceof FifoQueue)) {
@@ -778,17 +651,17 @@ FifoQueue.prototype.pollFirst = function fifoPollFirst() {
   }
   return item;
 };
-FifoQueue.prototype.getTotal = function fifoGetTotal() {
-  return this.total;
-};
 FifoQueue.prototype.getQueue = function fifoGetQueue() {
   return (this.first === 0 && this.last === this.queue.length) ?
       this.queue : this.queue.slice(this.first, this.last + 1);
 };
+/*
+FifoQueue.prototype.getTotal = function fifoGetTotal() {
+  return this.total;
+};
 FifoQueue.prototype.length = function fifoLength() {
   return (this.first >= 0) ? (this.last - this.first) + 1 : 0;
 };
-/*
 FifoQueue.prototype.at = function fifoAt(i) {
   return this.queue[this.first + i];
 };

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -312,12 +312,6 @@ MultipartDispatcher.prototype.promise = function dispatchMultipartPromise(
 
     partReaderQueue.removeFirst();
 
-    // Old style, where we make object AND queue it in operation
-    // metadataBuffer = operation.queueDocument(
-    //     (data.length === 0) ? null : data, rawHeaderQueue, metadataBuffer, objectQueue
-    //     );
-
-    // New style, we only make object in operation, add to queue here
     var madeObject = operation.makeObject(
         (data.length === 0) ? null : data, rawHeaderQueue
         );
@@ -563,6 +557,7 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   var drainListener = function objectDrainListener() {
     if (!hasEnded) {
       response.resume();
+      // Don't read if concat in progress to avoid double processing
       if (partReaderQueue.hasItem() && !isConcatenating) {
         isConcatenating = true;
         var partRead = concatStream(partFinisher);

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -22,6 +22,23 @@ var through2     = require('through2');
 var PromisePlus  = require('./bluebird-plus.js');
 var mlutil       = require('./mlutil.js');
 
+/**
+ * Handle response from the REST API based on response and operation
+ * @param {http.IncomingMessage} response - An HTTP response
+ *
+ * The following dispatch methods are available:
+ *
+ *   BodyDispatcher.emptyPromise()
+ *   BodyDispatcher.emptyStream()
+ *   BodyDispatcher.promise()
+ *   BodyDispatcher.chunkedStream()
+ *   BodyDispatcher.objectStream()
+ *   MultipartDispatcher.emptyPromise()
+ *   MultipartDispatcher.emptyStream()
+ *   MultipartDispatcher.promise()
+ *   MultipartDispatcher.chunkedStream()
+ *   MultipartDispatcher.objectStream()
+ */
 function responseDispatcher(response) {
   /*jshint validthis:true */
   var operation = this;
@@ -55,6 +72,8 @@ function responseDispatcher(response) {
   }
   var isMultipart = (responseBoundary != null);
 
+  // inputHeader may be boundary (for multipart) or content type (for body)
+  // Allows dispatch function signatures to remain consistent
   var inputHeader = isMultipart ? responseBoundary : responseType;
 
   var responseLength = response.headers['content-length'];
@@ -150,13 +169,15 @@ BodyDispatcher.prototype.promise = function dispatchBodyPromise(
 
   operation.logger.debug('body promise');
   var collectObject = function collectPromiseBodyObject(data) {
+    // turn collected data into something usable
+    // e.g., if JSON, parse as JS object
     operation.data = operation.collectBodyObject(data);
     resolvedPromise(operation, operation.resolve);
-    collectObject = null;
   };
 
   var isString = operation.copyResponseHeaders(response);
 
+  // concatStream accumulates response with callback
   response.pipe(concatStream(
       {encoding: (isString ? 'string' : 'buffer')},
       collectObject
@@ -169,6 +190,9 @@ BodyDispatcher.prototype.chunkedStream = function dispatchBodyChunkedStream(
 
   operation.logger.debug('body chunked stream');
 
+  // HTTP response gives a chunked stream to begin with
+  // .stream('chunked') creates through2 stream (writable and readable)
+  // Simply pipe HTTP response to the through2 stream
   response.pipe(operation.outputStream);
 };
 BodyDispatcher.prototype.objectStream = function dispatchBodyObjectStream(
@@ -178,16 +202,16 @@ BodyDispatcher.prototype.objectStream = function dispatchBodyObjectStream(
 
   operation.logger.debug('body object stream');
 
+  // outputStream is a through2 stream in object mode
   var outputStream = operation.outputStream;
 
   var collectObject = function collectStreamBodyObject(data) {
+    // similar to promise body case, but write to through2
     var writableObject = operation.collectBodyObject(data);
     if (writableObject != null) {
       outputStream.write(writableObject);
     }
     outputStream.end();
-
-    collectObject = null;
   };
 
   var isString = operation.copyResponseHeaders(response);
@@ -198,6 +222,10 @@ BodyDispatcher.prototype.objectStream = function dispatchBodyObjectStream(
       ));
 };
 
+// Multipart cases similar to the above, but with multiple objects
+// Promise case: Accumulate an array of objects
+// Chunked case: Send chunks (but filter out multipart bits -- e.g., headers)
+// Object stream case: Write multiple objects instead of single object
 function MultipartDispatcher(operation) {
   if (!(this instanceof MultipartDispatcher)) {
     return new MultipartDispatcher(operation);
@@ -248,8 +276,6 @@ MultipartDispatcher.prototype.promise = function dispatchMultipartPromise(
   var objectQueue     = new FifoQueue(2);
   var partReaderQueue = new FifoQueue(3);
 
-  var metadataBuffer  = null;
-
   var parsingParts = 0;
   var parsedParts  = 0;
 
@@ -257,8 +283,11 @@ MultipartDispatcher.prototype.promise = function dispatchMultipartPromise(
   var hasEnded  = false;
 
   var responseFinisher = function promiseResponseFinisher() {
-    if (metadataBuffer !== null) {
-      operation.queueMetadata(metadataBuffer, objectQueue);
+    // If there is metadata left in the buffer, add it to queue
+    if (operation.nextMetadataBuffer !== null) {
+      var metadataHeaders = operation.nextMetadataBuffer[0];
+      mlutil.copyProperties(operation.nextMetadataBuffer[1], metadataHeaders);
+      objectQueue.addLast(metadataHeaders);
     }
 
     operation.logger.debug('ending multipart promise');
@@ -283,9 +312,19 @@ MultipartDispatcher.prototype.promise = function dispatchMultipartPromise(
 
     partReaderQueue.removeFirst();
 
-    metadataBuffer = operation.queueDocument(
-        (data.length === 0) ? null : data, rawHeaderQueue, metadataBuffer, objectQueue
+    // Old style, where we make object AND queue it in operation
+    // metadataBuffer = operation.queueDocument(
+    //     (data.length === 0) ? null : data, rawHeaderQueue, metadataBuffer, objectQueue
+    //     );
+
+    // New style, we only make object in operation, add to queue here
+    var madeObject = operation.makeObject(
+        (data.length === 0) ? null : data, rawHeaderQueue
         );
+
+    if (madeObject !== null && madeObject !== undefined) {
+      objectQueue.addLast(madeObject);
+    }
 
     if (partReaderQueue.hasItem()) {
       var partConcatenator = concatStream(partFinisher);
@@ -295,9 +334,8 @@ MultipartDispatcher.prototype.promise = function dispatchMultipartPromise(
       partReadStream.pipe(partConcatenator);
     } else if (hasParsed) {
       responseFinisher();
-    } else if (!hasEnded) {
-      parser.emit('drain');
     }
+
   };
 
   var partHeadersListener = function promisePartHeadersListener(headers) {
@@ -418,7 +456,7 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   var errorListener   = operation.errorListener;
 
   var rawHeaderQueue = new FifoQueue(5);
-  var metadataBuffer = null;
+  var partReaderQueue = new FifoQueue(3);
 
   var parsingParts = 0;
   var parsedParts  = 0;
@@ -426,19 +464,69 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
   var hasParsed = false;
   var hasEnded  = false;
 
-  var partTransform = function objectPartQueueTransform(data) {
-    parsedParts++;
-    var objectQueue = queuedReader.getItemQueue();
-    metadataBuffer = operation.queueDocument(
-        (data.length === 0) ? null : data, rawHeaderQueue, metadataBuffer, objectQueue
-        );
-    doneChecker();
+  var responseFinisher = function objectResponseFinisher() {
+
+    if (!partReaderQueue.hasItem() && hasParsed && hasEnded) {
+
+      // If there is metadata left in the buffer, write it
+      if (operation.nextMetadataBuffer !== null) {
+        var metadataHeaders = operation.nextMetadataBuffer[0];
+        mlutil.copyProperties(operation.nextMetadataBuffer[1], metadataHeaders);
+        operation.outputStream.write(metadataHeaders);
+        operation.nextMetadataBuffer = null;
+      }
+
+      rawHeaderQueue      = null;
+      parser              = null;
+      partHeadersListener = null;
+      partListener        = null;
+      parseFinishListener = null;
+      responseEndListener = null;
+
+      operation.outputStream.end();
+    }
+
   };
 
-  var queuedReader = new QueuedReader(
-      {objectMode: true}, operation.logger, partTransform
-      );
-  this.queuedReader = queuedReader;
+  var partFinisher = function objectPartFinisher(data) {
+    parsedParts++;
+    operation.logger.debug('parsed part %d', parsedParts);
+
+    var madeObject = operation.makeObject(
+      (data.length === 0) ? null : data, rawHeaderQueue
+    );
+
+    var writeResult = null;
+    if (madeObject !== null && madeObject !== undefined) {
+      writeResult = operation.outputStream.write(madeObject);
+    }
+
+    // Manage backpressure
+    if (writeResult === false) {
+      // Only pause stream if not all parsed
+      if (hasParsed && !partReaderQueue.hasItem()) {
+        responseFinisher();
+      } else {
+        response.pause();
+      }
+      return;
+    }
+
+    partReaderQueue.removeFirst();
+
+    // If item avail, concat-stream it with callback to finisher
+    if (partReaderQueue.hasItem()) {
+
+      var partRead = concatStream(partFinisher);
+      partRead.on('error', errorListener);
+      var partReadStream = partReaderQueue.getFirst();
+      partReadStream.pipe(partRead);
+
+    } else if (hasParsed) {
+      responseFinisher();
+    }
+
+  };
 
   var partHeadersListener = function objectPartHeadersListener(headers) {
     operation.logger.debug('queued header');
@@ -447,49 +535,31 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
 
   var partListener = function objectPartListener(partReadStream) {
     parsingParts++;
+    operation.logger.debug('parsing part %d', parsingParts);
+
     partReadStream.on('header', partHeadersListener);
     partReadStream.on('error',  errorListener);
-    queuedReader.addReader(partReadStream);
+    partReaderQueue.addLast(partReadStream);
+
+    if (partReaderQueue.isLast()) {
+      var partRead = concatStream(partFinisher);
+      partRead.on('error', errorListener);
+      partReadStream.pipe(partRead);
+    }
   };
 
   var parseFinishListener = function objectParseFinishListener() {
     hasParsed = true;
-    doneChecker();
+    responseFinisher();
   };
 
   var responseEndListener = function objectResponseEndListener() {
     hasEnded = true;
-    doneChecker();
+    responseFinisher();
   };
 
-  /**
-   * Check if HTTP response has ended, Dicer has finished parsing,
-   * and the Queue is empty. If all are true, then we can call end()
-   * on output stream.
-   */
-  var doneChecker = function doneChecker() {
-
-    if (queuedReader.isQueueEmpty() && hasParsed && hasEnded) {
-      if (metadataBuffer !== null) {
-        var objectQueue = queuedReader.getItemQueue();
-        operation.queueMetadata(metadataBuffer, objectQueue);
-        metadataBuffer = null;
-      }
-
-      rawHeaderQueue      = null;
-      queuedReader        = null;
-      parser              = null;
-      partHeadersListener = null;
-      partListener        = null;
-      parseFinishListener = null;
-      responseEndListener = null;
-      partTransform       = null;
-
-      operation.outputStream.end();
-    } else if (!hasEnded && parsedParts === parsingParts) {
-      parser.emit('drain');
-    }
-
+  var drainListener = function objectDrainListener() {
+    response.resume();
   };
 
   var parser = new Dicer({boundary: boundary});
@@ -499,9 +569,10 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
 
   response.on('end', responseEndListener);
 
+  operation.outputStream.on('drain', drainListener);
+
   response.pipe(parser);
 
-  queuedReader.pipe(operation.outputStream);
 };
 
 /* Note:  Dicer appears to read ahead.
@@ -522,133 +593,133 @@ MultipartDispatcher.prototype.objectStream = function dispatchMultipartObjectStr
     part end 2
     finish
  */
-function QueuedReader(options, logger, itemsTransform) {
-  if (!(this instanceof QueuedReader)) {
-    return new QueuedReader(options, logger, itemsTransform);
-  }
-  stream.Readable.call(this, options);
+// function QueuedReader(options, logger, itemsTransform) {
+//   if (!(this instanceof QueuedReader)) {
+//     return new QueuedReader(options, logger, itemsTransform);
+//   }
+//   stream.Readable.call(this, options);
 
-  var self = this;
+//   var self = this;
 
-  this.itemsTransform = itemsTransform;
-  this.logger         = logger;
+//   this.itemsTransform = itemsTransform;
+//   this.logger         = logger;
 
-  this.minWriters =  5;
-  this.maxItems   = 10;
+//   this.minWriters =  5;
+//   this.maxItems   = 10;
 
-  this.readerQueue = new FifoQueue(10);
-  this.writerQueue = new FifoQueue(this.minWriters);
-  this.itemQueue   = new FifoQueue(this.maxItems);
+//   this.readerQueue = new FifoQueue(10);
+//   this.writerQueue = new FifoQueue(this.minWriters);
+//   this.itemQueue   = new FifoQueue(this.maxItems);
 
-  this.isReading = true;
-  this.queueDone = false;
+//   this.isReading = true;
+//   this.queueDone = false;
 
-  this.addItems = function queuedReaderAddItems(data) {
-    self.writerQueue.removeFirst();
+//   this.addItems = function queuedReaderAddItems(data) {
+//     self.writerQueue.removeFirst();
 
-    self.logger.debug('concatenated item');
+//     self.logger.debug('concatenated item');
 
-    var itemQueue    = self.itemQueue;
-    var beforeLength = itemQueue.length();
+//     var itemQueue    = self.itemQueue;
+//     var beforeLength = itemQueue.length();
 
-    self.itemsTransform(data);
+//     self.itemsTransform(data);
 
-    if (beforeLength < itemQueue.length()) {
-      if (beforeLength === 0) {
-        self.emit('readable');
-      }
-      if (self.isReading || isLast) {
-        logger.debug('writing first item');
-        self.isReading = self.push(itemQueue.pollFirst());
-      }
-    }
+//     if (beforeLength < itemQueue.length()) {
+//       if (beforeLength === 0) {
+//         self.emit('readable');
+//       }
+//       if (self.isReading || isLast) {
+//         logger.debug('writing first item');
+//         self.isReading = self.push(itemQueue.pollFirst());
+//       }
+//     }
 
-    self.nextReader();
-  };
-}
-util.inherits(QueuedReader, stream.Readable);
-QueuedReader.prototype.addReader = function queuedAddReader(reader) {
-  var readerQueue = this.readerQueue;
-  if (readerQueue === null) {
-    return;
-  }
+//     self.nextReader();
+//   };
+// }
+// util.inherits(QueuedReader, stream.Readable);
+// QueuedReader.prototype.addReader = function queuedAddReader(reader) {
+//   var readerQueue = this.readerQueue;
+//   if (readerQueue === null) {
+//     return;
+//   }
 
-  readerQueue.addLast(reader);
-  this.logger.debug('queued item %d', readerQueue.getTotal());
-  this.nextReader();
-};
-QueuedReader.prototype.getItemQueue = function getItemQueue() {
-  return this.itemQueue;
-};
-QueuedReader.prototype.isQueueEmpty = function isQueueEmpty() {
-  return (this.readerQueue.length() === 0 && this.writerQueue.length() === 0);
-};
-QueuedReader.prototype.nextReader = function queuedReaderNextReader() {
-  if (!this.isReading) {
-    return;
-  }
+//   readerQueue.addLast(reader);
+//   this.logger.debug('queued item %d', readerQueue.getTotal());
+//   this.nextReader();
+// };
+// QueuedReader.prototype.getItemQueue = function getItemQueue() {
+//   return this.itemQueue;
+// };
+// QueuedReader.prototype.isQueueEmpty = function isQueueEmpty() {
+//   return (this.readerQueue.length() === 0 && this.writerQueue.length() === 0);
+// };
+// QueuedReader.prototype.nextReader = function queuedReaderNextReader() {
+//   if (!this.isReading) {
+//     return;
+//   }
 
-  var readerQueue = this.readerQueue;
-  if (readerQueue === null || readerQueue.length() === 0) {
-    return;
-  }
+//   var readerQueue = this.readerQueue;
+//   if (readerQueue === null || readerQueue.length() === 0) {
+//     return;
+//   }
 
-  if (this.itemQueue.length() >= this.maxItems) {
-    return;
-  }
+//   if (this.itemQueue.length() >= this.maxItems) {
+//     return;
+//   }
 
-  var writerQueue = this.writerQueue;
-  var minWriters  = this.minWriters;
+//   var writerQueue = this.writerQueue;
+//   var minWriters  = this.minWriters;
 
-  var logger = this.logger;
+//   var logger = this.logger;
 
-  var addItems = this.addItems;
+//   var addItems = this.addItems;
 
-  var i = writerQueue.length();
-  var j = readerQueue.length();
-  var writer = null;
-  for (; i <= minWriters && j > 0; i++, j--) {
-    writer = concatStream(addItems);
-    writerQueue.addLast(writer);
-    logger.debug('reading item');
-    readerQueue.pollFirst().pipe(writer);
-  }
-};
-QueuedReader.prototype._read = function queuedReaderRead(/*size*/) {
-  var itemQueue = this.itemQueue;
-  if (itemQueue === null) {
-    return;
-  }
+//   var i = writerQueue.length();
+//   var j = readerQueue.length();
+//   var writer = null;
+//   for (; i <= minWriters && j > 0; i++, j--) {
+//     writer = concatStream(addItems);
+//     writerQueue.addLast(writer);
+//     logger.debug('reading item');
+//     readerQueue.pollFirst().pipe(writer);
+//   }
+// };
+// QueuedReader.prototype._read = function queuedReaderRead(/*size*/) {
+//   var itemQueue = this.itemQueue;
+//   if (itemQueue === null) {
+//     return;
+//   }
 
-  var logger = this.logger;
+//   var logger = this.logger;
 
-  var hasItem = itemQueue.hasItem();
-  var canRead = true;
-  while (hasItem && canRead) {
-    logger.debug('writing item');
-    canRead = this.push(itemQueue.pollFirst());
-    hasItem = itemQueue.hasItem();
-  }
+//   var hasItem = itemQueue.hasItem();
+//   var canRead = true;
+//   while (hasItem && canRead) {
+//     logger.debug('writing item');
+//     canRead = this.push(itemQueue.pollFirst());
+//     hasItem = itemQueue.hasItem();
+//   }
 
-  if (this.queueDone && !hasItem && this.readerQueue.length() === 0 &&
-      this.writerQueue.length() === 0) {
-    this.logger.debug('wrote %d items', itemQueue.getTotal());
-    this.push(null);
+//   if (this.queueDone && !hasItem && this.readerQueue.length() === 0 &&
+//       this.writerQueue.length() === 0) {
+//     this.logger.debug('wrote %d items', itemQueue.getTotal());
+//     this.push(null);
 
-    this.readerQueue = null;
-    this.writerQueue = null;
-    this.itemQueue   = null;
-  } else if (!canRead) {
-    if (this.isReading) {
-      this.isReading = false;
-    }
-  } else {
-    if (!this.isReading) {
-      this.isReading = true;
-    }
-    this.nextReader();
-  }
-};
+//     this.readerQueue = null;
+//     this.writerQueue = null;
+//     this.itemQueue   = null;
+//   } else if (!canRead) {
+//     if (this.isReading) {
+//       this.isReading = false;
+//     }
+//   } else {
+//     if (!this.isReading) {
+//       this.isReading = true;
+//     }
+//     this.nextReader();
+//   }
+// };
 
 function FifoQueue(min) {
   if (!(this instanceof FifoQueue)) {

--- a/test-basic/documents-core.js
+++ b/test-basic/documents-core.js
@@ -313,7 +313,7 @@ describe('document content', function(){
           })
         .catch(done);
       });
-      it('should read as a stream', function(done){
+      it('should read as a chunked stream', function(done){
         db.documents.read(uri).stream('chunked').on('error', done).
           pipe(
             concatStream({encoding: 'buffer'}, function(value) {
@@ -372,6 +372,57 @@ describe('document content', function(){
           done();
           })
         .catch(done);
+      });
+      it('should read as an object stream with content and metadata', function(done){
+        var count = 0;
+        db.documents.read({
+            uris: ['/test/write/arrayString1.json', '/test/write/arrayObject2.json'],
+            categories: ['content', 'quality']
+        }).stream('object').on('error', done).
+          on('data', function (data) {
+            count++;
+            valcheck.isObject(data).should.equal(true);
+            data.should.have.property('content');
+            data.should.have.property('quality');
+          }).
+          on('end', function () {
+            count.should.equal(2);
+            done();
+          });
+      });
+      it('should read as an object stream with content only', function(done){
+        var count = 0;
+        db.documents.read({
+            uris: ['/test/write/arrayString1.json', '/test/write/arrayObject2.json'],
+            categories: ['content']
+        }).stream('object').on('error', done).
+          on('data', function (data) {
+            count++;
+            valcheck.isObject(data).should.equal(true);
+            data.should.have.property('content');
+            data.should.not.have.property('quality');
+          }).
+          on('end', function () {
+            count.should.equal(2);
+            done();
+          });
+      });
+      it('should read as an object stream with metadata only', function(done){
+        var count = 0;
+        db.documents.read({
+            uris: ['/test/write/arrayString1.json', '/test/write/arrayObject2.json'],
+            categories: ['quality']
+        }).stream('object').on('error', done).
+          on('data', function (data) {
+            count++;
+            valcheck.isObject(data).should.equal(true);
+            data.should.not.have.property('content');
+            data.should.have.property('quality');
+          }).
+          on('end', function () {
+            count.should.equal(2);
+            done();
+          });
       });
     });
     describe('a JSON document in two chunks', function(){

--- a/test-basic/documents-query.js
+++ b/test-basic/documents-query.js
@@ -530,6 +530,24 @@ describe('document query', function(){
         })
       .catch(done);
     });
+    it('should get the query as an object stream with initial summary', function(done){
+      this.timeout(3000);
+      var objects = [];
+      db.documents.query(
+        q.where(
+          q.value('valueKey', 'match value')
+        ).withOptions({metrics: true})
+      ).stream('object')
+      .on('error', done)
+      .on('data', function (object) {
+        objects.push(object);
+      }).
+      on('end', function () {
+        objects[0].should.have.property('snippet-format');
+        objects[1].should.have.property('uri');
+        done();
+      });
+    });
   });
   describe('for a where clause with a parsed query', function() {
     it('should match a value query', function(done){


### PR DESCRIPTION
- Simplify the multipart object stream path. No longer use QueuedReader; instead write directly to the through2 output stream.
- Separate  object creation and object queuing for the multipart promise and multipart object stream cases. operation.makeObject() handles object creation; queuing (or writing) of the made objects is handled in the responder.
- Track metadata objects in a this.nextMetadataBuffer property in operation. 
- Add comments.