### PR TITLE
Ignore documentation of internal methods

### DIFF
--- a/lib/operation.js
+++ b/lib/operation.js
@@ -96,6 +96,8 @@ Operation.prototype.collectBodyObject = function collectBodyObject(data) {
  * @param {Buffer} data - Multipart part data
  * @param {FifoQueue} rawHeaderQueue - Queue of headers for part data
  * @return {Object} - The object
+ *
+ * @ignore
  */
 Operation.prototype.makeObject = function makeObject(
     data, rawHeaderQueue

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -38,6 +38,8 @@ var mlutil       = require('./mlutil.js');
  *   MultipartDispatcher.promise()
  *   MultipartDispatcher.chunkedStream()
  *   MultipartDispatcher.objectStream()
+ *
+ * @ignore
  */
 function responseDispatcher(response) {
   /*jshint validthis:true */


### PR DESCRIPTION
jsdoc script should not process responseDispatcher() or makeObject() for public API docs