### PR TITLE
Fix graphs#sparql documentation, 'documentQuery' to 'docQuery'

### DIFF
--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -601,7 +601,7 @@ Graphs.prototype.list = function listGraphs() {
  * @param {string|string[]} [defaultGraphs] - the default graphs for the SPARQL query
  * @param {string|string[]} [namedGraphs] - the named graphs for the SPARQL query
  * @param {string|ReadableStream} query - the SPARQL query
- * @param {object} [documentQuery] - a {@link queryBuilder.Query} returned
+ * @param {object} [docQuery] - a {@link queryBuilder.Query} returned
  * by the query builder functions that qualifies the documents
  * supplying the triples
  * @param {number} [start] - the zero-based position


### PR DESCRIPTION
Corrects parameter naming

Fixes #437