### PR TITLE
Rewrite temporal protect tests

### DIFF
--- a/test-basic/documents-temporal-protect.js
+++ b/test-basic/documents-temporal-protect.js
@@ -29,7 +29,7 @@ describe('temporal protect', function() {
     validStartTime:  '1111-11-11T11:11:11Z',
     validEndTime:    '9999-12-31T23:59:59Z'
   };
-  before(function(done){
+  it('should protect a temporal document with duration and default level', function(done) {
     db.documents.write({
       documents: {
         uri: 'tempDoc1.json',
@@ -37,63 +37,12 @@ describe('temporal protect', function() {
       },
       temporalCollection: 'temporalCollection'
     }).result(function(response){
-      return db.documents.write({
-        documents:{
-          uri: 'tempDoc2.json',
-          content: content
-        },
-        temporalCollection: 'temporalCollection'
-      }).result()
-    }).then(function(response){
-      return db.documents.write({
-        documents:{
-          uri: 'tempDoc3.json',
-          content: content
-        },
-        temporalCollection: 'temporalCollection'
-      }).result()
-    }).then(function(response){
-      return db.documents.write({
-        documents:{
-          uri: 'tempDoc4.json',
-          content: content
-        },
-        temporalCollection: 'temporalCollection'
-      }).result()
-    }).then(function(response){
-        done();
-    }).catch(done);
-  });
-  after(function(done){
-    db.documents.wipe({
+      return db.documents.protect({
         uri: 'tempDoc1.json',
-        temporalCollection: 'temporalCollection'
-    }).result(function(response){
-      return db.documents.wipe({
-        uri: 'tempDoc2.json',
-        temporalCollection: 'temporalCollection'
+        temporalCollection: 'temporalCollection',
+        duration: 'PT0S'
       }).result();
-    }).then(function(response){
-      return db.documents.wipe({
-        uri: 'tempDoc3.json',
-        temporalCollection: 'temporalCollection'
-      }).result();
-    }).then(function(response){
-      return db.documents.wipe({
-        uri: 'tempDoc4.json',
-        temporalCollection: 'temporalCollection'
-      }).result();
-    }).then(function(response){
-      fs.unlinkSync(archiveFile);
-      done();
-    }).catch(done);
-  });
-  it('should protect a temporal document with duration and default level', function(done) {
-    db.documents.protect({
-      uri: 'tempDoc1.json',
-      temporalCollection: 'temporalCollection',
-      duration: 'PT0S'
-    }).result(function(response) {
+    }).then(function(response) {
       response.uri.should.equal('tempDoc1.json');
       response.temporalCollection.should.equal('temporalCollection');
       response.level.should.equal(DEFAULT_LEVEL);
@@ -109,16 +58,29 @@ describe('temporal protect', function() {
       m.metadataValues.should.have.property('temporalProtectLevel');
       m.metadataValues.temporalProtectLevel.should.equal(DEFAULT_LEVEL);
       m.metadataValues.should.have.property('temporalProtectExTime');
+      return db.documents.wipe({
+        uri: 'tempDoc1.json',
+        temporalCollection: 'temporalCollection'
+      }).result();
+    }).then(function(response){
       done();
     }).catch(done);
   });
   it('should protect a temporal document with an expireTime and level', function(done) {
-    db.documents.protect({
-      uri: 'tempDoc2.json',
-      temporalCollection: 'temporalCollection',
-      expireTime: '2016-06-03T19:56:17.681154-07:00',
-      level: 'noWipe'
-    }).result(function(response) {
+    db.documents.write({
+      documents: {
+        uri: 'tempDoc2.json',
+        content: content
+      },
+      temporalCollection: 'temporalCollection'
+    }).result(function(response){
+      return db.documents.protect({
+        uri: 'tempDoc2.json',
+        temporalCollection: 'temporalCollection',
+        expireTime: '2016-06-03T19:56:17.681154-07:00',
+        level: 'noWipe'
+      }).result();
+    }).then(function(response) {
       response.uri.should.equal('tempDoc2.json');
       response.temporalCollection.should.equal('temporalCollection');
       response.level.should.equal('noWipe');
@@ -137,17 +99,30 @@ describe('temporal protect', function() {
       m.metadataValues.temporalProtectExTime.should.equal(
         '2016-06-03T19:56:17.681154-07:00'
       );
+      return db.documents.wipe({
+        uri: 'tempDoc2.json',
+        temporalCollection: 'temporalCollection'
+      }).result();
+    }).then(function(response){
       done();
-      })
-    .catch(done);
+    }).catch(done);
   });
+  // Jenkins skips archivePath test: https://bugtrack.marklogic.com/45783
   it('should protect a temporal document with a duration and archivePath', function(done) {
-    db.documents.protect({
-      uri: 'tempDoc3.json',
-      temporalCollection: 'temporalCollection',
-      duration: 'PT0S',
-      archivePath: archiveFile
-    }).result(function(response) {
+    db.documents.write({
+      documents: {
+        uri: 'tempDoc3.json',
+        content: content
+      },
+      temporalCollection: 'temporalCollection'
+    }).result(function(response){
+      return db.documents.protect({
+        uri: 'tempDoc3.json',
+        temporalCollection: 'temporalCollection',
+        duration: 'PT0S',
+        archivePath: archiveFile
+      }).result();
+    }).then(function(response){
       response.uri.should.equal('tempDoc3.json');
       response.temporalCollection.should.equal('temporalCollection');
       response.level.should.equal(DEFAULT_LEVEL);
@@ -165,16 +140,30 @@ describe('temporal protect', function() {
       m.metadataValues.should.have.property('temporalArchiveStatus');
       m.metadataValues.temporalArchiveStatus.should.equal('succeeded');
       m.metadataValues.should.have.property('temporalArchiveTime');
+      return db.documents.wipe({
+        uri: 'tempDoc3.json',
+        temporalCollection: 'temporalCollection'
+      }).result();
+    }).then(function(response){
+      fs.unlinkSync(archiveFile);
       done();
     }).catch(done);
   });
   it('should protect a temporal document twice', function(done) {
-    db.documents.protect({
-      uri: 'tempDoc4.json',
-      temporalCollection: 'temporalCollection',
-      expireTime: '2016-01-01T12:34:56.7890-07:00',
-      level: 'noUpdate'
-    }).result(function(response) {
+    db.documents.write({
+      documents: {
+        uri: 'tempDoc4.json',
+        content: content
+      },
+      temporalCollection: 'temporalCollection'
+    }).result(function(response){
+      return db.documents.protect({
+        uri: 'tempDoc4.json',
+        temporalCollection: 'temporalCollection',
+        expireTime: '2016-01-01T12:34:56.7890-07:00',
+        level: 'noUpdate'
+      }).result();
+    }).then(function(response){
       response.uri.should.equal('tempDoc4.json');
       response.temporalCollection.should.equal('temporalCollection');
       response.level.should.equal('noUpdate');
@@ -182,13 +171,17 @@ describe('temporal protect', function() {
         uri: 'tempDoc4.json',
         temporalCollection: 'temporalCollection',
         expireTime: '2016-01-01T12:34:56.7890-07:00',
-        level: 'noUpdate',
-        archivePath: archiveFile
+        level: 'noUpdate'
       }).result();
     }).then(function(response){
       response.uri.should.equal('tempDoc4.json');
       response.temporalCollection.should.equal('temporalCollection');
       response.level.should.equal('noUpdate');
+      return db.documents.wipe({
+        uri: 'tempDoc4.json',
+        temporalCollection: 'temporalCollection'
+      }).result();
+    }).then(function(response){
       done();
     }).catch(done);
   });


### PR DESCRIPTION
Rewritten so the archivePath test can be skipped by Jenkins, see:
https://bugtrack.marklogic.com/45783