### PR TITLE
Up Node.js version support to 6.9.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "http://github.com/marklogic/node-client-api.git"
   },
   "engines": {
-    "node": ">=6.3.1"
+    "node": ">=6.9.0"
   },
   "devDependencies": {
     "bunyan": "^1.3.3",


### PR DESCRIPTION
See: https://github.com/marklogic/node-client-api/issues/459