### PR TITLE
Fixes #514: Adds missing deps and npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ in the online resources. To run the examples, follow the instructions here:
 
 ### Generating Documentation Locally
 
-After installing the project dependencies (including the [gulp](http://gulpjs.com/) 
-build system), you can build the reference documentation locally from the root 
+After installing the project dependencies (including the [gulp](http://gulpjs.com/)
+build system), you can build the reference documentation locally from the root
 directory of the marklogic package:
 
-    gulp doc
+    npm run doc
 
 The documentation is generated in a doc subdirectory. The documentation can also be
 accessed online [here](https://docs.marklogic.com/jsdoc/index.html).
@@ -82,16 +82,16 @@ accessed online [here](https://docs.marklogic.com/jsdoc/index.html).
 To set up the database and REST server for tests, execute the following
 command from the root directory for the marklogic package:
 
-    node etc/test-setup.js
+    npm run test:setup
 
 After setup, you can run tests for the Node.js Client API with the following
 command:
 
-    gulp test
+    npm test
 
 To tear down the test database and REST server, execute the following:
 
-    node etc/test-teardown.js
+    npm run test:teardown
 
 ## Support
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,158 +2,4731 @@
   "name": "marklogic",
   "version": "2.1.1",
   "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "from": "ansi-styles@>=3.2.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "dev": true
+    },
     "big-integer": {
       "version": "1.6.25",
-      "from": "big-integer@>=1.6.25 <2.0.0",
+      "from": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz"
     },
     "bluebird": {
       "version": "3.5.1",
-      "from": "bluebird@>=3.5.1 <4.0.0",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "from": "bunyan@>=1.3.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "dev": true,
+      "dependencies": {
+        "dtrace-provider": {
+          "version": "0.8.7",
+          "from": "dtrace-provider@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "nan": {
+              "version": "2.12.1",
+              "from": "nan@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "moment": {
+          "version": "2.23.0",
+          "from": "moment@>=2.10.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "mv": {
+          "version": "2.1.1",
+          "from": "mv@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "ncp": {
+              "version": "2.0.0",
+              "from": "ncp@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+              "dev": true,
+              "optional": true
+            },
+            "rimraf": {
+              "version": "2.4.5",
+              "from": "rimraf@>=2.4.0 <2.5.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+              "dev": true,
+              "optional": true,
+              "dependencies": {
+                "glob": {
+                  "version": "6.0.4",
+                  "from": "glob@>=6.0.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "dev": true,
+                  "optional": true,
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "dev": true,
+                      "optional": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "dev": true,
+                      "optional": true,
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.11",
+                          "from": "brace-expansion@>=1.1.7 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                          "dev": true,
+                          "optional": true,
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "from": "balanced-match@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "safe-json-stringify": {
+          "version": "1.2.0",
+          "from": "safe-json-stringify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "chai": {
+      "version": "4.2.0",
+      "from": "chai@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.1.0",
+          "from": "assertion-error@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+          "dev": true
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "from": "check-error@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+          "dev": true
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "from": "deep-eql@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "dev": true
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "from": "get-func-name@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+          "dev": true
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "from": "pathval@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "from": "type-detect@>=4.0.5 <5.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "from": "chalk@>=2.4.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "from": "color-convert@>=1.9.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "from": "color-name@1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
-      "from": "concat-stream@>=1.6.0 <2.0.0",
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "deepcopy": {
       "version": "0.6.3",
-      "from": "deepcopy@>=0.6.3 <0.7.0",
+      "from": "https://registry.npmjs.org/deepcopy/-/deepcopy-0.6.3.tgz",
       "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-0.6.3.tgz"
     },
     "delimit-stream": {
       "version": "0.1.0",
-      "from": "delimit-stream@0.1.0",
+      "from": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz"
     },
     "dicer": {
       "version": "0.2.5",
-      "from": "dicer@>=0.2.5 <0.3.0",
+      "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        }
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "from": "domelementtype@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "from": "domhandler@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "dev": true
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "from": "domutils@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "from": "entities@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "dev": true
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "from": "gulp@>=3.8.10 <4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dev": true,
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "from": "deprecated@>=0.0.1 <0.0.2",
+          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+          "dev": true
+        },
+        "gulp-util": {
+          "version": "3.0.8",
+          "from": "gulp-util@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+          "dev": true,
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.1",
+              "from": "beeper@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+              "dev": true
+            },
+            "dateformat": {
+              "version": "2.2.0",
+              "from": "dateformat@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+              "dev": true
+            },
+            "fancy-log": {
+              "version": "1.3.3",
+              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-gray": {
+                  "version": "0.1.1",
+                  "from": "ansi-gray@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-wrap": {
+                      "version": "0.1.0",
+                      "from": "ansi-wrap@0.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "color-support": {
+                  "version": "1.1.3",
+                  "from": "color-support@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+                  "dev": true
+                },
+                "parse-node-version": {
+                  "version": "1.0.0",
+                  "from": "parse-node-version@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
+                  "dev": true
+                },
+                "time-stamp": {
+                  "version": "1.1.0",
+                  "from": "time-stamp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "from": "gulplog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.2",
+                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.1",
+                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.1",
+                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "from": "vinyl@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.4",
+                  "from": "clone@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.2.0",
+          "from": "interpret@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+          "dev": true
+        },
+        "liftoff": {
+          "version": "2.5.0",
+          "from": "liftoff@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "extend": {
+              "version": "3.0.2",
+              "from": "extend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+              "dev": true
+            },
+            "findup-sync": {
+              "version": "2.0.0",
+              "from": "findup-sync@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "detect-file": {
+                  "version": "1.0.0",
+                  "from": "detect-file@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+                  "dev": true
+                },
+                "is-glob": {
+                  "version": "3.1.0",
+                  "from": "is-glob@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "2.1.1",
+                      "from": "is-extglob@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "micromatch": {
+                  "version": "3.1.10",
+                  "from": "micromatch@>=3.0.4 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "4.0.0",
+                      "from": "arr-diff@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                      "dev": true
+                    },
+                    "array-unique": {
+                      "version": "0.3.2",
+                      "from": "array-unique@>=0.3.2 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                      "dev": true
+                    },
+                    "braces": {
+                      "version": "2.3.2",
+                      "from": "braces@>=2.3.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.1.0",
+                          "from": "arr-flatten@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                          "dev": true
+                        },
+                        "extend-shallow": {
+                          "version": "2.0.1",
+                          "from": "extend-shallow@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "fill-range": {
+                          "version": "4.0.0",
+                          "from": "fill-range@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-number": {
+                              "version": "3.0.0",
+                              "from": "is-number@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.6",
+                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "repeat-string@>=1.6.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "dev": true
+                            },
+                            "to-regex-range": {
+                              "version": "2.1.1",
+                              "from": "to-regex-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "3.0.1",
+                          "from": "isobject@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                          "dev": true
+                        },
+                        "repeat-element": {
+                          "version": "1.1.3",
+                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+                          "dev": true
+                        },
+                        "snapdragon-node": {
+                          "version": "2.1.1",
+                          "from": "snapdragon-node@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "define-property": {
+                              "version": "1.0.0",
+                              "from": "define-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "is-descriptor": {
+                                  "version": "1.0.2",
+                                  "from": "is-descriptor@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-accessor-descriptor": {
+                                      "version": "1.0.0",
+                                      "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                                      "dev": true
+                                    },
+                                    "is-data-descriptor": {
+                                      "version": "1.0.0",
+                                      "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "snapdragon-util": {
+                              "version": "3.0.1",
+                              "from": "snapdragon-util@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.6",
+                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "split-string": {
+                          "version": "3.1.0",
+                          "from": "split-string@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "extend-shallow": {
+                              "version": "3.0.2",
+                              "from": "extend-shallow@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "assign-symbols": {
+                                  "version": "1.0.0",
+                                  "from": "assign-symbols@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+                                  "dev": true
+                                },
+                                "is-extendable": {
+                                  "version": "1.0.1",
+                                  "from": "is-extendable@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "define-property": {
+                      "version": "2.0.2",
+                      "from": "define-property@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "is-descriptor": {
+                          "version": "1.0.2",
+                          "from": "is-descriptor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-accessor-descriptor": {
+                              "version": "1.0.0",
+                              "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                              "dev": true
+                            },
+                            "is-data-descriptor": {
+                              "version": "1.0.0",
+                              "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "3.0.1",
+                          "from": "isobject@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "3.0.2",
+                      "from": "extend-shallow@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "assign-symbols": {
+                          "version": "1.0.0",
+                          "from": "assign-symbols@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+                          "dev": true
+                        },
+                        "is-extendable": {
+                          "version": "1.0.1",
+                          "from": "is-extendable@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "2.0.4",
+                      "from": "extglob@>=2.0.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "define-property": {
+                          "version": "1.0.0",
+                          "from": "define-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-descriptor": {
+                              "version": "1.0.2",
+                              "from": "is-descriptor@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "is-accessor-descriptor": {
+                                  "version": "1.0.0",
+                                  "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                                  "dev": true
+                                },
+                                "is-data-descriptor": {
+                                  "version": "1.0.0",
+                                  "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "2.1.4",
+                          "from": "expand-brackets@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "debug": {
+                              "version": "2.6.9",
+                              "from": "debug@>=2.3.3 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "ms": {
+                                  "version": "2.0.0",
+                                  "from": "ms@2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "define-property": {
+                              "version": "0.2.5",
+                              "from": "define-property@>=0.2.5 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "is-descriptor": {
+                                  "version": "0.1.6",
+                                  "from": "is-descriptor@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-accessor-descriptor": {
+                                      "version": "0.1.6",
+                                      "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.6",
+                                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                              "dev": true
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "is-data-descriptor": {
+                                      "version": "0.1.4",
+                                      "from": "is-data-descriptor@>=0.1.4 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.6",
+                                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                              "dev": true
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "kind-of": {
+                                      "version": "5.1.0",
+                                      "from": "kind-of@>=5.0.0 <6.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "posix-character-classes": {
+                              "version": "0.1.1",
+                              "from": "posix-character-classes@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "extend-shallow": {
+                          "version": "2.0.1",
+                          "from": "extend-shallow@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "fragment-cache": {
+                      "version": "0.2.1",
+                      "from": "fragment-cache@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "map-cache": {
+                          "version": "0.2.2",
+                          "from": "map-cache@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "kind-of": {
+                      "version": "6.0.2",
+                      "from": "kind-of@>=6.0.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                      "dev": true
+                    },
+                    "nanomatch": {
+                      "version": "1.2.13",
+                      "from": "nanomatch@>=1.2.9 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "is-windows": {
+                          "version": "1.0.2",
+                          "from": "is-windows@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "object.pick": {
+                      "version": "1.3.0",
+                      "from": "object.pick@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "isobject": {
+                          "version": "3.0.1",
+                          "from": "isobject@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "regex-not": {
+                      "version": "1.0.2",
+                      "from": "regex-not@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "safe-regex": {
+                          "version": "1.1.0",
+                          "from": "safe-regex@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "ret": {
+                              "version": "0.1.15",
+                              "from": "ret@>=0.1.10 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "snapdragon": {
+                      "version": "0.8.2",
+                      "from": "snapdragon@>=0.8.1 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "base": {
+                          "version": "0.11.2",
+                          "from": "base@>=0.11.1 <0.12.0",
+                          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "cache-base": {
+                              "version": "1.0.1",
+                              "from": "cache-base@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "collection-visit": {
+                                  "version": "1.0.0",
+                                  "from": "collection-visit@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "map-visit": {
+                                      "version": "1.0.0",
+                                      "from": "map-visit@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+                                      "dev": true
+                                    },
+                                    "object-visit": {
+                                      "version": "1.0.1",
+                                      "from": "object-visit@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "get-value": {
+                                  "version": "2.0.6",
+                                  "from": "get-value@>=2.0.6 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+                                  "dev": true
+                                },
+                                "has-value": {
+                                  "version": "1.0.0",
+                                  "from": "has-value@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "has-values": {
+                                      "version": "1.0.0",
+                                      "from": "has-values@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "3.0.0",
+                                          "from": "is-number@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.2.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "dev": true,
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.6",
+                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                                  "dev": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "kind-of": {
+                                          "version": "4.0.0",
+                                          "from": "kind-of@>=4.0.0 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.6",
+                                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                              "dev": true
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "set-value": {
+                                  "version": "2.0.0",
+                                  "from": "set-value@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-extendable": {
+                                      "version": "0.1.1",
+                                      "from": "is-extendable@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                                      "dev": true
+                                    },
+                                    "split-string": {
+                                      "version": "3.1.0",
+                                      "from": "split-string@>=3.0.1 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "extend-shallow": {
+                                          "version": "3.0.2",
+                                          "from": "extend-shallow@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "assign-symbols": {
+                                              "version": "1.0.0",
+                                              "from": "assign-symbols@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+                                              "dev": true
+                                            },
+                                            "is-extendable": {
+                                              "version": "1.0.1",
+                                              "from": "is-extendable@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                                              "dev": true
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "to-object-path": {
+                                  "version": "0.3.0",
+                                  "from": "to-object-path@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.2.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.6",
+                                          "from": "is-buffer@>=1.1.5 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "union-value": {
+                                  "version": "1.0.0",
+                                  "from": "union-value@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "arr-union": {
+                                      "version": "3.1.0",
+                                      "from": "arr-union@>=3.1.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+                                      "dev": true
+                                    },
+                                    "is-extendable": {
+                                      "version": "0.1.1",
+                                      "from": "is-extendable@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                                      "dev": true
+                                    },
+                                    "set-value": {
+                                      "version": "0.4.3",
+                                      "from": "set-value@>=0.4.3 <0.5.0",
+                                      "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "unset-value": {
+                                  "version": "1.0.0",
+                                  "from": "unset-value@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "has-value": {
+                                      "version": "0.3.1",
+                                      "from": "has-value@>=0.3.1 <0.4.0",
+                                      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "has-values": {
+                                          "version": "0.1.4",
+                                          "from": "has-values@>=0.1.4 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                                          "dev": true
+                                        },
+                                        "isobject": {
+                                          "version": "2.1.0",
+                                          "from": "isobject@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "class-utils": {
+                              "version": "0.3.6",
+                              "from": "class-utils@>=0.3.5 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "arr-union": {
+                                  "version": "3.1.0",
+                                  "from": "arr-union@>=3.1.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+                                  "dev": true
+                                },
+                                "define-property": {
+                                  "version": "0.2.5",
+                                  "from": "define-property@>=0.2.5 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-descriptor": {
+                                      "version": "0.1.6",
+                                      "from": "is-descriptor@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "is-accessor-descriptor": {
+                                          "version": "0.1.6",
+                                          "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.2.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "dev": true,
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.6",
+                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                                  "dev": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "is-data-descriptor": {
+                                          "version": "0.1.4",
+                                          "from": "is-data-descriptor@>=0.1.4 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.2.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "dev": true,
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.6",
+                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                                  "dev": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "kind-of": {
+                                          "version": "5.1.0",
+                                          "from": "kind-of@>=5.0.0 <6.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "static-extend": {
+                                  "version": "0.1.2",
+                                  "from": "static-extend@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "object-copy": {
+                                      "version": "0.1.0",
+                                      "from": "object-copy@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "copy-descriptor": {
+                                          "version": "0.1.1",
+                                          "from": "copy-descriptor@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+                                          "dev": true
+                                        },
+                                        "kind-of": {
+                                          "version": "3.2.2",
+                                          "from": "kind-of@>=3.0.3 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                          "dev": true,
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.6",
+                                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                              "dev": true
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "component-emitter": {
+                              "version": "1.2.1",
+                              "from": "component-emitter@>=1.2.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                              "dev": true
+                            },
+                            "define-property": {
+                              "version": "1.0.0",
+                              "from": "define-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "is-descriptor": {
+                                  "version": "1.0.2",
+                                  "from": "is-descriptor@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "is-accessor-descriptor": {
+                                      "version": "1.0.0",
+                                      "from": "is-accessor-descriptor@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                                      "dev": true
+                                    },
+                                    "is-data-descriptor": {
+                                      "version": "1.0.0",
+                                      "from": "is-data-descriptor@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "isobject": {
+                              "version": "3.0.1",
+                              "from": "isobject@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                              "dev": true
+                            },
+                            "mixin-deep": {
+                              "version": "1.3.1",
+                              "from": "mixin-deep@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "1.0.2",
+                                  "from": "for-in@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                                  "dev": true
+                                },
+                                "is-extendable": {
+                                  "version": "1.0.1",
+                                  "from": "is-extendable@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "pascalcase": {
+                              "version": "0.1.1",
+                              "from": "pascalcase@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "2.6.9",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "from": "ms@2.0.0",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "define-property": {
+                          "version": "0.2.5",
+                          "from": "define-property@>=0.2.5 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-descriptor": {
+                              "version": "0.1.6",
+                              "from": "is-descriptor@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "is-accessor-descriptor": {
+                                  "version": "0.1.6",
+                                  "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.2.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.6",
+                                          "from": "is-buffer@>=1.1.5 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-data-descriptor": {
+                                  "version": "0.1.4",
+                                  "from": "is-data-descriptor@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                                  "dev": true,
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.2.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "dev": true,
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.6",
+                                          "from": "is-buffer@>=1.1.5 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "kind-of": {
+                                  "version": "5.1.0",
+                                  "from": "kind-of@>=5.0.0 <6.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "extend-shallow": {
+                          "version": "2.0.1",
+                          "from": "extend-shallow@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "map-cache": {
+                          "version": "0.2.2",
+                          "from": "map-cache@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+                          "dev": true
+                        },
+                        "source-map": {
+                          "version": "0.5.7",
+                          "from": "source-map@>=0.5.6 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                          "dev": true
+                        },
+                        "source-map-resolve": {
+                          "version": "0.5.2",
+                          "from": "source-map-resolve@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "atob": {
+                              "version": "2.1.2",
+                              "from": "atob@>=2.1.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+                              "dev": true
+                            },
+                            "decode-uri-component": {
+                              "version": "0.2.0",
+                              "from": "decode-uri-component@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+                              "dev": true
+                            },
+                            "resolve-url": {
+                              "version": "0.2.1",
+                              "from": "resolve-url@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+                              "dev": true
+                            },
+                            "source-map-url": {
+                              "version": "0.4.0",
+                              "from": "source-map-url@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+                              "dev": true
+                            },
+                            "urix": {
+                              "version": "0.1.0",
+                              "from": "urix@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "use": {
+                          "version": "3.1.1",
+                          "from": "use@>=3.1.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "to-regex": {
+                      "version": "3.0.2",
+                      "from": "to-regex@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "safe-regex": {
+                          "version": "1.1.0",
+                          "from": "safe-regex@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "ret": {
+                              "version": "0.1.15",
+                              "from": "ret@>=0.1.10 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve-dir": {
+                  "version": "1.0.1",
+                  "from": "resolve-dir@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "expand-tilde": {
+                      "version": "2.0.2",
+                      "from": "expand-tilde@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "homedir-polyfill": {
+                          "version": "1.0.1",
+                          "from": "homedir-polyfill@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "parse-passwd": {
+                              "version": "1.0.0",
+                              "from": "parse-passwd@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "global-modules": {
+                      "version": "1.0.0",
+                      "from": "global-modules@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "global-prefix": {
+                          "version": "1.0.2",
+                          "from": "global-prefix@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "homedir-polyfill": {
+                              "version": "1.0.1",
+                              "from": "homedir-polyfill@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "parse-passwd": {
+                                  "version": "1.0.0",
+                                  "from": "parse-passwd@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "ini": {
+                              "version": "1.3.5",
+                              "from": "ini@>=1.3.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+                              "dev": true
+                            },
+                            "which": {
+                              "version": "1.3.1",
+                              "from": "which@>=1.2.14 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "isexe": {
+                                  "version": "2.0.0",
+                                  "from": "isexe@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "1.0.2",
+                          "from": "is-windows@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "fined": {
+              "version": "1.1.1",
+              "from": "fined@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "expand-tilde": {
+                  "version": "2.0.2",
+                  "from": "expand-tilde@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "homedir-polyfill": {
+                      "version": "1.0.1",
+                      "from": "homedir-polyfill@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "parse-passwd": {
+                          "version": "1.0.0",
+                          "from": "parse-passwd@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "object.defaults": {
+                  "version": "1.1.0",
+                  "from": "object.defaults@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "array-each": {
+                      "version": "1.0.1",
+                      "from": "array-each@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+                      "dev": true
+                    },
+                    "array-slice": {
+                      "version": "1.1.0",
+                      "from": "array-slice@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+                      "dev": true
+                    },
+                    "for-own": {
+                      "version": "1.0.0",
+                      "from": "for-own@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "for-in": {
+                          "version": "1.0.2",
+                          "from": "for-in@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "isobject": {
+                      "version": "3.0.1",
+                      "from": "isobject@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "object.pick": {
+                  "version": "1.3.0",
+                  "from": "object.pick@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "isobject": {
+                      "version": "3.0.1",
+                      "from": "isobject@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "parse-filepath": {
+                  "version": "1.0.2",
+                  "from": "parse-filepath@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "1.0.0",
+                      "from": "is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "1.0.0",
+                          "from": "is-relative@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "is-unc-path": {
+                              "version": "1.0.0",
+                              "from": "is-unc-path@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+                              "dev": true,
+                              "dependencies": {
+                                "unc-path-regex": {
+                                  "version": "0.1.2",
+                                  "from": "unc-path-regex@>=0.1.2 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "1.0.2",
+                          "from": "is-windows@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-cache": {
+                      "version": "0.2.2",
+                      "from": "map-cache@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+                      "dev": true
+                    },
+                    "path-root": {
+                      "version": "0.1.1",
+                      "from": "path-root@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "path-root-regex": {
+                          "version": "0.1.2",
+                          "from": "path-root-regex@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "1.0.1",
+              "from": "flagged-respawn@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+              "dev": true
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "from": "is-plain-object@>=2.0.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+              "dev": true,
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "from": "isobject@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "object.map": {
+              "version": "1.0.1",
+              "from": "object.map@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "for-own": {
+                  "version": "1.0.0",
+                  "from": "for-own@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "for-in": {
+                      "version": "1.0.2",
+                      "from": "for-in@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "make-iterator": {
+                  "version": "1.0.1",
+                  "from": "make-iterator@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "6.0.2",
+                      "from": "kind-of@>=6.0.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "from": "rechoir@>=0.6.2 <0.7.0",
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "dev": true
+            },
+            "resolve": {
+              "version": "1.9.0",
+              "from": "resolve@>=1.1.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "path-parse": {
+                  "version": "1.0.6",
+                  "from": "path-parse@>=1.0.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        },
+        "orchestrator": {
+          "version": "0.3.8",
+          "from": "orchestrator@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+          "dev": true,
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "from": "end-of-stream@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "dev": true,
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "sequencify@>=0.0.7 <0.1.0",
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "dev": true
+            },
+            "stream-consume": {
+              "version": "0.1.1",
+              "from": "stream-consume@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+              "dev": true
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "1.0.3",
+          "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "dev": true
+        },
+        "tildify": {
+          "version": "1.2.0",
+          "from": "tildify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "dev": true
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "from": "v8flags@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "dev": true
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.14",
+          "from": "vinyl-fs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "dev": true,
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.3",
+              "from": "defaults@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.4",
+                  "from": "clone@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@>=3.1.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dev": true,
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "dev": true
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dev": true,
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.2",
+                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@>=3.1.21 <3.2.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "dev": true
+                            },
+                            "inherits": {
+                              "version": "1.0.2",
+                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "dev": true
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.11",
+              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "dev": true,
+              "dependencies": {
+                "natives": {
+                  "version": "1.1.6",
+                  "from": "natives@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "dev": true
+                },
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dev": true,
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dev": true,
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-jsdoc3": {
+      "version": "1.0.1",
+      "from": "gulp-jsdoc3@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-jsdoc3/-/gulp-jsdoc3-1.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "dev": true,
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.8",
+          "from": "gulp-util@>=3.0.7 <4.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+          "dev": true,
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.1",
+              "from": "beeper@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "dateformat": {
+              "version": "2.2.0",
+              "from": "dateformat@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+              "dev": true
+            },
+            "fancy-log": {
+              "version": "1.3.3",
+              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-gray": {
+                  "version": "0.1.1",
+                  "from": "ansi-gray@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-wrap": {
+                      "version": "0.1.0",
+                      "from": "ansi-wrap@0.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "color-support": {
+                  "version": "1.1.3",
+                  "from": "color-support@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+                  "dev": true
+                },
+                "parse-node-version": {
+                  "version": "1.0.0",
+                  "from": "parse-node-version@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
+                  "dev": true
+                },
+                "time-stamp": {
+                  "version": "1.1.0",
+                  "from": "time-stamp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "from": "gulplog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.2",
+                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.1",
+                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.1",
+                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "dev": true
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "from": "vinyl@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.4",
+                  "from": "clone@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "ink-docstrap": {
+          "version": "1.3.2",
+          "from": "ink-docstrap@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ink-docstrap/-/ink-docstrap-1.3.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "moment": {
+              "version": "2.23.0",
+              "from": "moment@>=2.14.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+              "dev": true
+            },
+            "sanitize-html": {
+              "version": "1.20.0",
+              "from": "sanitize-html@>=1.13.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "chalk": {
+                  "version": "2.4.2",
+                  "from": "chalk@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.1",
+                      "from": "ansi-styles@>=3.2.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.9.3",
+                          "from": "color-convert@>=1.9.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@1.1.3",
+                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "dev": true
+                    },
+                    "supports-color": {
+                      "version": "5.5.0",
+                      "from": "supports-color@>=5.3.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "has-flag": {
+                          "version": "3.0.0",
+                          "from": "has-flag@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "htmlparser2": {
+                  "version": "3.10.0",
+                  "from": "htmlparser2@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.1",
+                      "from": "domelementtype@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+                      "dev": true
+                    },
+                    "domhandler": {
+                      "version": "2.4.2",
+                      "from": "domhandler@>=2.3.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+                      "dev": true
+                    },
+                    "domutils": {
+                      "version": "1.7.0",
+                      "from": "domutils@>=1.5.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "from": "dom-serializer@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "dev": true,
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "from": "domelementtype@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.1.2",
+                      "from": "entities@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                      "dev": true
+                    },
+                    "readable-stream": {
+                      "version": "3.1.1",
+                      "from": "readable-stream@>=3.0.6 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "string_decoder": {
+                          "version": "1.2.0",
+                          "from": "string_decoder@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.clonedeep": {
+                  "version": "4.5.0",
+                  "from": "lodash.clonedeep@>=4.5.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+                  "dev": true
+                },
+                "lodash.escaperegexp": {
+                  "version": "4.1.2",
+                  "from": "lodash.escaperegexp@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+                  "dev": true
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "from": "lodash.isplainobject@>=4.0.6 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "dev": true
+                },
+                "lodash.isstring": {
+                  "version": "4.0.1",
+                  "from": "lodash.isstring@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+                  "dev": true
+                },
+                "lodash.mergewith": {
+                  "version": "4.6.1",
+                  "from": "lodash.mergewith@>=4.6.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+                  "dev": true
+                },
+                "postcss": {
+                  "version": "7.0.13",
+                  "from": "postcss@>=7.0.5 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.6.1",
+                      "from": "source-map@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                      "dev": true
+                    },
+                    "supports-color": {
+                      "version": "6.1.0",
+                      "from": "supports-color@>=6.1.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "has-flag": {
+                          "version": "3.0.0",
+                          "from": "has-flag@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "srcset": {
+                  "version": "1.0.0",
+                  "from": "srcset@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.3",
+                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                      "dev": true
+                    },
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "map-stream": {
+          "version": "0.0.6",
+          "from": "map-stream@0.0.6",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.6.tgz",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.28",
+          "from": "tmp@0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "dev": true,
+          "dependencies": {
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "from": "os-tmpdir@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "gulp-jshint": {
+      "version": "2.1.0",
+      "from": "gulp-jshint@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "from": "lodash@>=4.12.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dev": true,
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "from": "brace-expansion@>=1.1.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "dev": true,
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "from": "balanced-match@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "plugin-error": {
+          "version": "0.1.2",
+          "from": "plugin-error@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "ansi-cyan": {
+              "version": "0.1.1",
+              "from": "ansi-cyan@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-wrap": {
+                  "version": "0.1.0",
+                  "from": "ansi-wrap@0.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "ansi-red": {
+              "version": "0.1.1",
+              "from": "ansi-red@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-wrap": {
+                  "version": "0.1.0",
+                  "from": "ansi-wrap@0.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "arr-diff": {
+              "version": "1.1.0",
+              "from": "arr-diff@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "arr-flatten": {
+                  "version": "1.1.0",
+                  "from": "arr-flatten@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+                  "dev": true
+                },
+                "array-slice": {
+                  "version": "0.2.3",
+                  "from": "array-slice@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "arr-union": {
+              "version": "2.1.0",
+              "from": "arr-union@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "1.1.4",
+              "from": "extend-shallow@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+              "dev": true,
+              "dependencies": {
+                "kind-of": {
+                  "version": "1.1.0",
+                  "from": "kind-of@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "rcloader": {
+          "version": "0.2.2",
+          "from": "rcloader@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.2.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "lodash.assign": {
+              "version": "4.2.0",
+              "from": "lodash.assign@>=4.2.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+              "dev": true
+            },
+            "lodash.isobject": {
+              "version": "3.0.2",
+              "from": "lodash.isobject@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+              "dev": true
+            },
+            "lodash.merge": {
+              "version": "4.6.1",
+              "from": "lodash.merge@>=4.6.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+              "dev": true
+            },
+            "rcfinder": {
+              "version": "0.1.9",
+              "from": "rcfinder@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.9.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash.clonedeep": {
+                  "version": "4.5.0",
+                  "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-mocha": {
+      "version": "4.3.1",
+      "from": "gulp-mocha@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-4.3.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "dargs": {
+          "version": "5.1.0",
+          "from": "dargs@>=5.1.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.6.3",
+          "from": "execa@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+          "dev": true,
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "from": "cross-spawn@>=5.0.1 <6.0.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.1.5",
+                  "from": "lru-cache@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "from": "pseudomap@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                      "dev": true
+                    },
+                    "yallist": {
+                      "version": "2.1.2",
+                      "from": "yallist@>=2.1.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "shebang-command": {
+                  "version": "1.2.0",
+                  "from": "shebang-command@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "shebang-regex": {
+                      "version": "1.0.0",
+                      "from": "shebang-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.3.1",
+                  "from": "which@>=1.2.9 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "isexe": {
+                      "version": "2.0.0",
+                      "from": "isexe@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "from": "get-stream@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "dev": true
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "from": "p-finally@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "from": "signal-exit@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "dev": true
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "from": "strip-eof@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.8",
+          "from": "gulp-util@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+          "dev": true,
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.1",
+              "from": "beeper@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "dateformat": {
+              "version": "2.2.0",
+              "from": "dateformat@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+              "dev": true
+            },
+            "fancy-log": {
+              "version": "1.3.3",
+              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "ansi-gray": {
+                  "version": "0.1.1",
+                  "from": "ansi-gray@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "ansi-wrap": {
+                      "version": "0.1.0",
+                      "from": "ansi-wrap@0.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "color-support": {
+                  "version": "1.1.3",
+                  "from": "color-support@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+                  "dev": true
+                },
+                "parse-node-version": {
+                  "version": "1.0.0",
+                  "from": "parse-node-version@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
+                  "dev": true
+                },
+                "time-stamp": {
+                  "version": "1.1.0",
+                  "from": "time-stamp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "from": "gulplog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.2",
+                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.1",
+                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.1",
+                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "dev": true
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "from": "vinyl@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.4",
+                  "from": "clone@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mocha": {
+          "version": "3.5.3",
+          "from": "mocha@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+          "dev": true,
+          "dependencies": {
+            "browser-stdout": {
+              "version": "1.3.0",
+              "from": "browser-stdout@1.3.0",
+              "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+              "dev": true
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dev": true,
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "diff": {
+              "version": "3.2.0",
+              "from": "diff@3.2.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "dev": true
+            },
+            "glob": {
+              "version": "7.1.1",
+              "from": "glob@7.1.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "dev": true
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "minimatch@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.11",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "growl": {
+              "version": "1.9.2",
+              "from": "growl@1.9.2",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+              "dev": true
+            },
+            "he": {
+              "version": "1.1.1",
+              "from": "he@1.1.1",
+              "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+              "dev": true
+            },
+            "json3": {
+              "version": "3.3.2",
+              "from": "json3@3.3.2",
+              "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+              "dev": true
+            },
+            "lodash.create": {
+              "version": "3.1.1",
+              "from": "lodash.create@3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "dev": true
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dev": true,
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "dev": true
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.1.0",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                          "dev": true
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._basecreate": {
+                  "version": "3.0.3",
+                  "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "from": "supports-color@3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "from": "npm-run-path@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "path-key": {
+              "version": "2.0.1",
+              "from": "path-key@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "from": "has-flag@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.0",
+      "from": "htmlparser2@>=3.10.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.1.1",
+          "from": "readable-stream@>=3.0.6 <4.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "from": "string_decoder@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "dev": true
         }
       }
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.3 <3.0.0",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "intercept-stdout": {
+      "version": "0.1.2",
+      "from": "intercept-stdout@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "lodash.toarray": {
+          "version": "3.0.2",
+          "from": "lodash.toarray@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+              "dev": true
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "dev": true,
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "dev": true
+                },
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+    },
+    "jsdoc": {
+      "version": "3.5.5",
+      "from": "jsdoc@>=3.5.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+      "dev": true,
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.19",
+          "from": "babylon@7.0.0-beta.19",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+          "dev": true
+        },
+        "catharsis": {
+          "version": "0.8.9",
+          "from": "catharsis@>=0.8.9 <0.9.0",
+          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+          "dev": true,
+          "dependencies": {
+            "underscore-contrib": {
+              "version": "0.3.0",
+              "from": "underscore-contrib@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "dev": true
+        },
+        "js2xmlparser": {
+          "version": "3.0.0",
+          "from": "js2xmlparser@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "xmlcreate": {
+              "version": "1.0.2",
+              "from": "xmlcreate@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+              "dev": true
+            }
+          }
+        },
+        "klaw": {
+          "version": "2.0.0",
+          "from": "klaw@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.15",
+              "from": "graceful-fs@>=4.1.9 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+              "dev": true
+            }
+          }
+        },
+        "marked": {
+          "version": "0.3.19",
+          "from": "marked@>=0.3.6 <0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "dev": true
+            }
+          }
+        },
+        "requizzle": {
+          "version": "0.2.1",
+          "from": "requizzle@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "from": "underscore@>=1.6.0 <1.7.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "dev": true
+        },
+        "taffydb": {
+          "version": "2.6.2",
+          "from": "taffydb@2.6.2",
+          "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "from": "underscore@>=1.8.3 <1.9.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "jshint": {
+      "version": "2.9.7",
+      "from": "jshint@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.7.tgz",
+      "dev": true,
+      "dependencies": {
+        "cli": {
+          "version": "1.0.1",
+          "from": "cli@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "7.1.3",
+              "from": "glob@>=7.1.1 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "dev": true,
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "dev": true
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "dev": true
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "dev": true,
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.3.1",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+              "dev": true
+            },
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "dev": true
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dev": true,
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "dev": true
+                    },
+                    "entities": {
+                      "version": "1.1.2",
+                      "from": "entities@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "dev": true,
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "from": "lodash@>=4.17.10 <4.18.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dev": true,
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "from": "brace-expansion@>=1.1.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "dev": true,
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "from": "balanced-match@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "dev": true
+        }
+      }
     },
     "json-text-sequence": {
       "version": "0.1.1",
-      "from": "json-text-sequence@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz"
     },
     "kerberos": {
       "version": "0.0.23",
-      "from": "kerberos@>=0.0.23 <0.0.24",
+      "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.23.tgz",
       "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.23.tgz",
       "optional": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "from": "lodash.clonedeep@>=4.5.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "from": "lodash.escaperegexp@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "from": "lodash.isplainobject@>=4.0.6 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "from": "lodash.isstring@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "from": "lodash.mergewith@>=4.6.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "dev": true
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "from": "mocha@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "from": "browser-stdout@1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.11.0",
+          "from": "commander@2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "from": "debug@3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "from": "diff@3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dev": true,
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.4 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dev": true,
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                  "dev": true,
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dev": true,
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "dev": true
+            }
+          }
+        },
+        "growl": {
+          "version": "1.10.3",
+          "from": "growl@1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "dev": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "from": "he@1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "from": "supports-color@4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "2.0.0",
+              "from": "has-flag@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.23.0",
+      "from": "moment@latest",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "dev": true
+    },
     "multipart-stream": {
       "version": "2.0.1",
-      "from": "multipart-stream@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/multipart-stream/-/multipart-stream-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/multipart-stream/-/multipart-stream-2.0.1.tgz"
     },
     "nan": {
       "version": "2.5.1",
-      "from": "nan@>=2.5.1 <2.6.0",
+      "from": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
       "optional": true
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "dev": true
+    },
+    "postcss": {
+      "version": "7.0.13",
+      "from": "postcss@>=7.0.5 <8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.13.tgz",
+      "dev": true,
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "from": "supports-color@>=6.1.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "dev": true
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "qs": {
       "version": "6.5.1",
-      "from": "qs@>=6.5.1 <7.0.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+    },
+    "read": {
+      "version": "1.0.7",
+      "from": "read@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "dev": true,
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.8",
+          "from": "mute-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "dev": true
+        }
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
-      "from": "readable-stream@>=2.2.2 <3.0.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
     },
     "safe-buffer": {
       "version": "5.1.1",
-      "from": "safe-buffer@>=5.1.1 <5.2.0",
+      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
     "sandwich-stream": {
       "version": "1.0.0",
-      "from": "sandwich-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-1.0.0.tgz"
+    },
+    "sanitize-html": {
+      "version": "1.20.0",
+      "from": "sanitize-html@latest",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz",
+      "dev": true
+    },
+    "should": {
+      "version": "13.2.3",
+      "from": "should@>=13.1.3 <14.0.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "should-equal": {
+          "version": "2.0.0",
+          "from": "should-equal@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+          "dev": true
+        },
+        "should-format": {
+          "version": "3.0.3",
+          "from": "should-format@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+          "dev": true
+        },
+        "should-type": {
+          "version": "1.4.0",
+          "from": "should-type@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+          "dev": true
+        },
+        "should-type-adaptors": {
+          "version": "1.1.0",
+          "from": "should-type-adaptors@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+          "dev": true
+        },
+        "should-util": {
+          "version": "1.0.0",
+          "from": "should-util@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "from": "source-map@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "dev": true
+    },
+    "srcset": {
+      "version": "1.0.0",
+      "from": "srcset@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+      "dev": true
     },
     "streamsearch": {
       "version": "0.1.2",
-      "from": "streamsearch@0.1.2",
+      "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
     },
     "string_decoder": {
       "version": "1.0.3",
-      "from": "string_decoder@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "from": "supports-color@>=5.3.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "dev": true
     },
     "through2": {
       "version": "2.0.3",
-      "from": "through2@>=2.0.3 <3.0.0",
+      "from": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "winston": {
+      "version": "2.4.4",
+      "from": "winston@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "from": "async@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "dev": true
+        },
+        "cycle": {
+          "version": "1.0.3",
+          "from": "cycle@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+          "dev": true
+        },
+        "eyes": {
+          "version": "0.1.8",
+          "from": "eyes@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "dev": true
+        },
+        "stack-trace": {
+          "version": "0.0.10",
+          "from": "stack-trace@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+          "dev": true
+        }
+      }
     },
     "www-authenticate": {
       "version": "0.6.2",
-      "from": "www-authenticate@>=0.6.2 <0.7.0",
+      "from": "https://registry.npmjs.org/www-authenticate/-/www-authenticate-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/www-authenticate/-/www-authenticate-0.6.2.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <4.1.0",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yakaa": {
       "version": "1.0.1",
-      "from": "yakaa@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "version": "2.1.1",
   "license": "Apache-2.0",
   "main": "./lib/marklogic.js",
+  "scripts": {
+    "doc": "gulp doc",
+    "test:setup": "node etc/test-setup.js",
+    "test:teardown": "node etc/test-teardown.js",
+    "test": "gulp test"
+  },
   "keywords": [
     "marklogic",
     "nosql",
@@ -41,6 +47,7 @@
   },
   "devDependencies": {
     "bunyan": "^1.3.3",
+    "chai": "^4.1.2",
     "core-util-is": "^1.0.1",
     "gulp": "^3.8.10",
     "gulp-jsdoc3": "^1.0.1",
@@ -50,8 +57,9 @@
     "jsdoc": "^3.5.5",
     "jshint": "^2.6.0",
     "mocha": "^4.0.1",
-    "chai": "^4.1.2",
+    "moment": "^2.23.0",
     "read": "^1.0.5",
+    "sanitize-html": "^1.20.0",
     "should": "^13.1.3",
     "winston": "^2.3.1"
   },


### PR DESCRIPTION
Added the missing `moment` and `sanitize-html` dependencies.

Wrapped the various script executables into the `package.json` scripts
block, also updating the README.md to reflect it.