### PR TITLE
Update all copyright year to 2020

### DIFF
--- a/config-optic/connectdef.js
+++ b/config-optic/connectdef.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MarkLogic Corporation
+ * Copyright 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config-optic/qa-data/mapperReducer.sjs
+++ b/config-optic/qa-data/mapperReducer.sjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config-optic/setupqa.js
+++ b/config-optic/setupqa.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MarkLogic Corporation
+ * Copyright 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config-optic/teardown.js
+++ b/config-optic/teardown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MarkLogic Corporation
+ * Copyright 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config-optic/testlib.js
+++ b/config-optic/testlib.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/data/masterDetail.tdex
+++ b/etc/data/masterDetail.tdex
@@ -1,5 +1,5 @@
 <?xml  version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2016-2019 MarkLogic Corporation -->
+<!-- Copyright 2016-2020 MarkLogic Corporation -->
 <template xmlns="http://marklogic.com/xdmp/tde">
   <context>/sets</context>
   <templates>

--- a/etc/data/masterDetail.xml
+++ b/etc/data/masterDetail.xml
@@ -1,5 +1,5 @@
 <?xml  version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2016-2019 MarkLogic Corporation -->
+<!-- Copyright 2016-2020 MarkLogic Corporation -->
 <sets>
 <masterSet>
   <master><id>1</id><name>Master 1</name><date>2015-12-01</date></master>

--- a/etc/data/musician.tdex
+++ b/etc/data/musician.tdex
@@ -1,5 +1,5 @@
 <?xml  version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2016-2019 MarkLogic Corporation -->
+<!-- Copyright 2016-2020 MarkLogic Corporation -->
 <template xmlns="http://marklogic.com/xdmp/tde">
   <context>/musician</context>
   <rows>

--- a/etc/data/rowPostProcessors.sjs
+++ b/etc/data/rowPostProcessors.sjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/data/tripleSets.xml
+++ b/etc/data/tripleSets.xml
@@ -1,5 +1,5 @@
 <?xml  version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2016-2019 MarkLogic Corporation -->
+<!-- Copyright 2016-2020 MarkLogic Corporation -->
 <tripleSets xmlns:sem="http://marklogic.com/semantics">
 <masterRelated>
   <sem:triples>

--- a/etc/test-config-qa-ssl.js
+++ b/etc/test-config-qa-ssl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-config-qa.js
+++ b/etc/test-config-qa.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-config.js
+++ b/etc/test-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-lib.js
+++ b/etc/test-lib.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-setup-prompt.js
+++ b/etc/test-setup-prompt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-setup-qa.js
+++ b/etc/test-setup-qa.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-setup-users.js
+++ b/etc/test-setup-users.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-setup.js
+++ b/etc/test-setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-teardown-qa.js
+++ b/etc/test-teardown-qa.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/test-teardown.js
+++ b/etc/test-teardown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/etc/users-setup.js
+++ b/etc/users-setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/all.js
+++ b/examples/all.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/before-load.js
+++ b/examples/before-load.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/example-util.js
+++ b/examples/example-util.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/optimistic-locking.js
+++ b/examples/optimistic-locking.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/patch-document.js
+++ b/examples/patch-document.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/probe-document.js
+++ b/examples/probe-document.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/query-builder.js
+++ b/examples/query-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/query-by-example.js
+++ b/examples/query-by-example.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/query-extract.js
+++ b/examples/query-extract.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/query-parser.js
+++ b/examples/query-parser.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/read-documents.js
+++ b/examples/read-documents.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/read-metadata.js
+++ b/examples/read-metadata.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/read-rows.js
+++ b/examples/read-rows.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/read-stream.js
+++ b/examples/read-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/setup.js
+++ b/examples/setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/transform-on-client.js
+++ b/examples/transform-on-client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/write-remove.js
+++ b/examples/write-remove.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/write-stream.js
+++ b/examples/write-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -6,7 +6,7 @@
   "templates": {
     "theme":                "marklogic",
     "systemName":           "MarkLogic Node.js Client API",
-    "copyright":            "Copyright 2014-2019 MarkLogic Corporation",
+    "copyright":            "Copyright 2014-2020 MarkLogic Corporation",
     "navType":              "vertical",
     "inverseNav":           true,
     "includeDate":          false,

--- a/lib/bluebird-plus.js
+++ b/lib/bluebird-plus.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright 2015-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/extlibs.js
+++ b/lib/extlibs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/graphs.js
+++ b/lib/graphs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/mllog.js
+++ b/lib/mllog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/mlutil.js
+++ b/lib/mlutil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/operation.js
+++ b/lib/operation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 MarkLogic Corporation
+ * Copyright 2015-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/optional.js
+++ b/lib/optional.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/patch-builder.js
+++ b/lib/patch-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/plan-builder-base.js
+++ b/lib/plan-builder-base.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/plan-builder-generated.js
+++ b/lib/plan-builder-generated.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/plan-builder.js
+++ b/lib/plan-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/resources-config.js
+++ b/lib/resources-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/resources-exec.js
+++ b/lib/resources-exec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/rest-server-properties.js
+++ b/lib/rest-server-properties.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/rows.js
+++ b/lib/rows.js
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/server-exec.js
+++ b/lib/server-exec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/server-types-generated.js
+++ b/lib/server-types-generated.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/values-builder.js
+++ b/lib/values-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic-proxy/ml-modules/testInspector.sjs
+++ b/test-basic-proxy/ml-modules/testInspector.sjs
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright 2018-2019 MarkLogic Corporation
+ * Copyright 2018-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/client.js
+++ b/test-basic/client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/data/directoryConstraint.xqy
+++ b/test-basic/data/directoryConstraint.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/echoModule.js
+++ b/test-basic/data/echoModule.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/data/echoModule.xqy
+++ b/test-basic/data/echoModule.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/extractFirst.xqy
+++ b/test-basic/data/extractFirst.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/flagTransform.xqy
+++ b/test-basic/data/flagTransform.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/objectify.xqy
+++ b/test-basic/data/objectify.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/timeService.xqy
+++ b/test-basic/data/timeService.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/data/timestampTransform.js
+++ b/test-basic/data/timestampTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/data/versionService.js
+++ b/test-basic/data/versionService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/data/wrapperService.xqy
+++ b/test-basic/data/wrapperService.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-basic/documents-core.js
+++ b/test-basic/documents-core.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-negative.js
+++ b/test-basic/documents-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-patch.js
+++ b/test-basic/documents-patch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-query.js
+++ b/test-basic/documents-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-quick.js
+++ b/test-basic/documents-quick.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-temporal-document.js
+++ b/test-basic/documents-temporal-document.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-temporal-patch.js
+++ b/test-basic/documents-temporal-patch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-temporal-protect.js
+++ b/test-basic/documents-temporal-protect.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-temporal-wipe.js
+++ b/test-basic/documents-temporal-wipe.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-temporal.js
+++ b/test-basic/documents-temporal.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-transform.js
+++ b/test-basic/documents-transform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/documents-version.js
+++ b/test-basic/documents-version.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/endpoint-proxy.js
+++ b/test-basic/endpoint-proxy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 MarkLogic Corporation
+ * Copyright 2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/errors.js
+++ b/test-basic/errors.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/extlibs.js
+++ b/test-basic/extlibs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/graphs.js
+++ b/test-basic/graphs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/logging.js
+++ b/test-basic/logging.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/patch-builder.js
+++ b/test-basic/patch-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-aggregates.js
+++ b/test-basic/plan-aggregates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-builder-base.js
+++ b/test-basic/plan-builder-base.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-builder-generated.js
+++ b/test-basic/plan-builder-generated.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-composers.js
+++ b/test-basic/plan-composers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-documents.js
+++ b/test-basic/plan-documents.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-expressions.js
+++ b/test-basic/plan-expressions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-lexicons.js
+++ b/test-basic/plan-lexicons.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-literals.js
+++ b/test-basic/plan-literals.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-modifiers.js
+++ b/test-basic/plan-modifiers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-nodes.js
+++ b/test-basic/plan-nodes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 MarkLogic Corporation
+ * Copyright 2017-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-processors.js
+++ b/test-basic/plan-processors.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-triples.js
+++ b/test-basic/plan-triples.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/plan-views.js
+++ b/test-basic/plan-views.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 MarkLogic Corporation
+ * Copyright 2016-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/probe.js
+++ b/test-basic/probe.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/query-builder.js
+++ b/test-basic/query-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/removeAll.js
+++ b/test-basic/removeAll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/resources-config.js
+++ b/test-basic/resources-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/resources-exec.js
+++ b/test-basic/resources-exec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/rest-server-properties.js
+++ b/test-basic/rest-server-properties.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/rows.js
+++ b/test-basic/rows.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/server-exec.js
+++ b/test-basic/server-exec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/suggest.js
+++ b/test-basic/suggest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/test-util.js
+++ b/test-basic/test-util.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/timestamp.js
+++ b/test-basic/timestamp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/transactions.js
+++ b/test-basic/transactions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/values-builder.js
+++ b/test-basic/values-builder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-basic/values.js
+++ b/test-basic/values.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/directoryConstraint.xqy
+++ b/test-complete/data/directoryConstraint.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/emptyTransform.js
+++ b/test-complete/data/emptyTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/extractFirst.xqy
+++ b/test-complete/data/extractFirst.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/flagTransform.xqy
+++ b/test-complete/data/flagTransform.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/objectify.xqy
+++ b/test-complete/data/objectify.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/paramTransform.js
+++ b/test-complete/data/paramTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceParams.js
+++ b/test-complete/data/sourceParams.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceParams.xqy
+++ b/test-complete/data/sourceParams.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceParamsNegative.js
+++ b/test-complete/data/sourceParamsNegative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceParamsNegative.xqy
+++ b/test-complete/data/sourceParamsNegative.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceSimple.js
+++ b/test-complete/data/sourceSimple.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceSimple.xqy
+++ b/test-complete/data/sourceSimple.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceSimpleNegative.js
+++ b/test-complete/data/sourceSimpleNegative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/data/sourceSimpleNegative.xqy
+++ b/test-complete/data/sourceSimpleNegative.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 (:
- : Copyright 2014-2019 MarkLogic Corporation
+ : Copyright 2014-2020 MarkLogic Corporation
  :
  : Licensed under the Apache License, Version 2.0 (the "License");
  : you may not use this file except in compliance with the License.

--- a/test-complete/data/timestampTransform.js
+++ b/test-complete/data/timestampTransform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-config-patch-negative.js
+++ b/test-complete/nodejs-config-patch-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-config-patch.js
+++ b/test-complete/nodejs-config-patch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-config-query-negative.js
+++ b/test-complete/nodejs-config-query-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-config-query.js
+++ b/test-complete/nodejs-config-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-database-concurrency.js
+++ b/test-complete/nodejs-database-concurrency.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-database-connection-negative.js
+++ b/test-complete/nodejs-database-connection-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-database-connection-ssl.js
+++ b/test-complete/nodejs-database-connection-ssl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-binary-gif.js
+++ b/test-complete/nodejs-documents-binary-gif.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-binary-mp3.js
+++ b/test-complete/nodejs-documents-binary-mp3.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-binary-pdf.js
+++ b/test-complete/nodejs-documents-binary-pdf.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-binary-range.js
+++ b/test-complete/nodejs-documents-binary-range.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-crud-negative.js
+++ b/test-complete/nodejs-documents-crud-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-crud.js
+++ b/test-complete/nodejs-documents-crud.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-extract-negative.js
+++ b/test-complete/nodejs-documents-extract-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-extract.js
+++ b/test-complete/nodejs-documents-extract.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-metadata-values.js
+++ b/test-complete/nodejs-documents-metadata-values.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-parse-2.js
+++ b/test-complete/nodejs-documents-parse-2.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-parse.js
+++ b/test-complete/nodejs-documents-parse.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-2.js
+++ b/test-complete/nodejs-documents-patch-2.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-datatypes.js
+++ b/test-complete/nodejs-documents-patch-datatypes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-metadata.js
+++ b/test-complete/nodejs-documents-patch-metadata.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-negative.js
+++ b/test-complete/nodejs-documents-patch-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-null.js
+++ b/test-complete/nodejs-documents-patch-null.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch-stream.js
+++ b/test-complete/nodejs-documents-patch-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-patch.js
+++ b/test-complete/nodejs-documents-patch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-qbe.js
+++ b/test-complete/nodejs-documents-qbe.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-2.js
+++ b/test-complete/nodejs-documents-query-2.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-3.js
+++ b/test-complete/nodejs-documents-query-3.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-facet.js
+++ b/test-complete/nodejs-documents-query-facet.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-geo-double.js
+++ b/test-complete/nodejs-documents-query-geo-double.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-geo-region.js
+++ b/test-complete/nodejs-documents-query-geo-region.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-geo.js
+++ b/test-complete/nodejs-documents-query-geo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-negative.js
+++ b/test-complete/nodejs-documents-query-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-options.js
+++ b/test-complete/nodejs-documents-query-options.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-slice.js
+++ b/test-complete/nodejs-documents-query-slice.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-sort.js
+++ b/test-complete/nodejs-documents-query-sort.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query-stream.js
+++ b/test-complete/nodejs-documents-query-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-query.js
+++ b/test-complete/nodejs-documents-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-quick.js
+++ b/test-complete/nodejs-documents-quick.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-read-chunk.js
+++ b/test-complete/nodejs-documents-read-chunk.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-remove-multiple.js
+++ b/test-complete/nodejs-documents-remove-multiple.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-removeAll-all.js
+++ b/test-complete/nodejs-documents-removeAll-all.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-removeAll-negative.js
+++ b/test-complete/nodejs-documents-removeAll-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-removeAll.js
+++ b/test-complete/nodejs-documents-removeAll.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-resources-config.js
+++ b/test-complete/nodejs-documents-resources-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-resources.js
+++ b/test-complete/nodejs-documents-resources.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-suggest.js
+++ b/test-complete/nodejs-documents-suggest.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-transaction-combo.js
+++ b/test-complete/nodejs-documents-transaction-combo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-transaction-remove.js
+++ b/test-complete/nodejs-documents-transaction-remove.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-transaction-timelimit.js
+++ b/test-complete/nodejs-documents-transaction-timelimit.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-transaction-withstate.js
+++ b/test-complete/nodejs-documents-transaction-withstate.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-transaction.js
+++ b/test-complete/nodejs-documents-transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-values-negative.js
+++ b/test-complete/nodejs-documents-values-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-values.js
+++ b/test-complete/nodejs-documents-values.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-write-large.js
+++ b/test-complete/nodejs-documents-write-large.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-documents-write-stream.js
+++ b/test-complete/nodejs-documents-write-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-extlibs-negative.js
+++ b/test-complete/nodejs-extlibs-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-extlibs.js
+++ b/test-complete/nodejs-extlibs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-content-type.js
+++ b/test-complete/nodejs-graphs-content-type.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-default.js
+++ b/test-complete/nodejs-graphs-default.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-merge-stream.js
+++ b/test-complete/nodejs-graphs-merge-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-merge.js
+++ b/test-complete/nodejs-graphs-merge.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-negative.js
+++ b/test-complete/nodejs-graphs-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-overwrite-stream.js
+++ b/test-complete/nodejs-graphs-overwrite-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-overwrite.js
+++ b/test-complete/nodejs-graphs-overwrite.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-read-write-stream.js
+++ b/test-complete/nodejs-graphs-read-write-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-repair.js
+++ b/test-complete/nodejs-graphs-repair.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-transaction-remove.js
+++ b/test-complete/nodejs-graphs-transaction-remove.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-graphs-transaction.js
+++ b/test-complete/nodejs-graphs-transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-104.js
+++ b/test-complete/nodejs-issue-104.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-108-109.js
+++ b/test-complete/nodejs-issue-108-109.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-110.js
+++ b/test-complete/nodejs-issue-110.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-115.js
+++ b/test-complete/nodejs-issue-115.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-257.js
+++ b/test-complete/nodejs-issue-257.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-issue-99.js
+++ b/test-complete/nodejs-issue-99.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-eval-negative.js
+++ b/test-complete/nodejs-javascript-eval-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-eval-params.js
+++ b/test-complete/nodejs-javascript-eval-params.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-eval.js
+++ b/test-complete/nodejs-javascript-eval.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-invoke-params-negative.js
+++ b/test-complete/nodejs-javascript-invoke-params-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-invoke-params.js
+++ b/test-complete/nodejs-javascript-invoke-params.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-invoke-simple-negative.js
+++ b/test-complete/nodejs-javascript-invoke-simple-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-javascript-invoke-simple.js
+++ b/test-complete/nodejs-javascript-invoke-simple.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-logger-bunyan.js
+++ b/test-complete/nodejs-logger-bunyan.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-logger-winston.js
+++ b/test-complete/nodejs-logger-winston.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-cts-queries.js
+++ b/test-complete/nodejs-optic-cts-queries.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-lexicons.js
+++ b/test-complete/nodejs-optic-from-lexicons.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-literals.js
+++ b/test-complete/nodejs-optic-from-literals.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-sparql.js
+++ b/test-complete/nodejs-optic-from-sparql.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-sql.js
+++ b/test-complete/nodejs-optic-from-sql.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-triples.js
+++ b/test-complete/nodejs-optic-from-triples.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-from-views.js
+++ b/test-complete/nodejs-optic-from-views.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-nodes.js
+++ b/test-complete/nodejs-optic-nodes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optic-read-file.js
+++ b/test-complete/nodejs-optic-read-file.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optimistic-locking-stream.js
+++ b/test-complete/nodejs-optimistic-locking-stream.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-optimistic-locking.js
+++ b/test-complete/nodejs-optimistic-locking.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-pitq-documents.js
+++ b/test-complete/nodejs-pitq-documents.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-pitq-graphs.js
+++ b/test-complete/nodejs-pitq-graphs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-pitq-values.js
+++ b/test-complete/nodejs-pitq-values.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-process-env.js
+++ b/test-complete/nodejs-process-env.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-serverprops.js
+++ b/test-complete/nodejs-serverprops.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-sparql-update.js
+++ b/test-complete/nodejs-sparql-update.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-sparql.js
+++ b/test-complete/nodejs-sparql.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-advance-lsqt.js
+++ b/test-complete/nodejs-temporal-advance-lsqt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-insert-bulk.js
+++ b/test-complete/nodejs-temporal-insert-bulk.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-insert-lsqt.js
+++ b/test-complete/nodejs-temporal-insert-lsqt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-insert-transform.js
+++ b/test-complete/nodejs-temporal-insert-transform.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-insert.js
+++ b/test-complete/nodejs-temporal-insert.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-lsqt-query.js
+++ b/test-complete/nodejs-temporal-lsqt-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-patch.js
+++ b/test-complete/nodejs-temporal-patch.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-period-compare-query.js
+++ b/test-complete/nodejs-temporal-period-compare-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-period-range-query-multiple-axis.js
+++ b/test-complete/nodejs-temporal-period-range-query-multiple-axis.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-period-range-query.js
+++ b/test-complete/nodejs-temporal-period-range-query.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-protect-delete.js
+++ b/test-complete/nodejs-temporal-protect-delete.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-protect-update.js
+++ b/test-complete/nodejs-temporal-protect-update.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-protect-wipe.js
+++ b/test-complete/nodejs-temporal-protect-wipe.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-transaction-commit.js
+++ b/test-complete/nodejs-temporal-transaction-commit.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-transaction-rollback.js
+++ b/test-complete/nodejs-temporal-transaction-rollback.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-update-lsqt.js
+++ b/test-complete/nodejs-temporal-update-lsqt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-temporal-update.js
+++ b/test-complete/nodejs-temporal-update.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-combine.js
+++ b/test-complete/nodejs-transform-combine.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-empty.js
+++ b/test-complete/nodejs-transform-empty.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-javascript.js
+++ b/test-complete/nodejs-transform-javascript.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-negative.js
+++ b/test-complete/nodejs-transform-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-params.js
+++ b/test-complete/nodejs-transform-params.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-save-json-as-xml.js
+++ b/test-complete/nodejs-transform-save-json-as-xml.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-xquery.js
+++ b/test-complete/nodejs-transform-xquery.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-transform-xslt.js
+++ b/test-complete/nodejs-transform-xslt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-eval-negative.js
+++ b/test-complete/nodejs-xquery-eval-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-eval.js
+++ b/test-complete/nodejs-xquery-eval.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-invoke-params-negative.js
+++ b/test-complete/nodejs-xquery-invoke-params-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-invoke-params.js
+++ b/test-complete/nodejs-xquery-invoke-params.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-invoke-simple-negative.js
+++ b/test-complete/nodejs-xquery-invoke-simple-negative.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-complete/nodejs-xquery-invoke-simple.js
+++ b/test-complete/nodejs-xquery-invoke-simple.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 MarkLogic Corporation
+ * Copyright 2014-2020 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I noticed that the footer of the JSDoc had a copyright year as 2019, but was recently published in 2020:

>Copyright 2014-2019 MarkLogic Corporation
>Documentation generated by JSDoc 3.6.3 on 2020-01-24T12:57:58-08:00 using the DocStrap template.

This PR updates the jsdoc.json and all of the other file files that had an outdated Copyright year to 2020