### PR TITLE
#543 - prefer ipv4 to ipv6 addresses

### DIFF
--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -41,6 +41,7 @@ var Operation            = require('./operation.js');
 var requester            = require('./requester.js');
 
 const proxy              = require("./endpoint-proxy.js");
+const dns = require('dns');
 
 /**
  * Provides functions to connect to a MarkLogic database and to build
@@ -731,6 +732,7 @@ function initClient(client, inputParams) {
       connectionParams.authType = 'DIGEST';
     }
   }
+  connectionParams.lookup = prefLookup;
 
   const authType = connectionParams.authType.toUpperCase();
   if (authType !== 'NONE' &&
@@ -809,6 +811,37 @@ function setSliceMode(mode) {
   }
 
   mlutil.setSliceMode(mode);
+}
+
+function prefLookup(hostname, options, callback) {
+  let isMultipleLookup = false;
+  if (options instanceof Function) {
+    callback = options;
+  } else if (options instanceof Object && options.all === true) {
+    isMultipleLookup = true;
+  }
+  // pass the preferred addresses or address to the callback
+  const prefCallback = isMultipleLookup ? callback : (err, addresses) => {
+    if (err) {
+      callback.call(null, err);
+    } else {
+      let addressdef = null;
+      // look for an ipv4 address
+      for (let i=0; i < addresses.length; i++) {
+        const candidate = addresses[i];
+        if (candidate.family === 4) {
+          addressdef = candidate;
+          break;
+        }
+      }
+      // fallback to first ipv6 address
+      if (addressdef === null) {
+        addressdef = addresses[0];
+      }
+      callback.call(null, null, addressdef.address, addressdef.family);
+    }
+  };
+  dns.lookup(hostname, {all:true, verbatim:false}, prefCallback);
 }
 
 module.exports = {


### PR DESCRIPTION
MarkLogic server prefers ipv4 addresses to ipv6 addresses.

Because the client's address factors into validation of the nonce in DIGEST authentication, the client must continue to use the same address while using the nonce.