### PR TITLE
#568 - rejectUnauthorized option ignored in webpacked typescript (impacts mlxprs extension in latest VSCode on Mac)

### DIFF
--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -778,8 +778,7 @@ function initClient(client, inputParams) {
     client.request = https.request;
     if (noAgent) {
       mlutil.copyProperties(inputParams, agentOptions, [
-        'keepAliveMsecs', 'maxSockets', 'maxTotalSockets',
-        'maxFreeSockets', 'timeout', 'scheduling'
+        'keepAliveMsecs', 'maxCachedSessions', 'maxFreeSockets', 'maxSockets', 'maxTotalSockets', 'scheduling', 'timeout'
       ]);
       connectionParams.agent = new https.Agent(agentOptions);
     } else {
@@ -789,9 +788,7 @@ function initClient(client, inputParams) {
     client.request = http.request;
     if (noAgent) {
       mlutil.copyProperties(inputParams, agentOptions, [
-        'ca', 'cert', 'ciphers', 'keepAliveMsecs', 'key', 'maxSockets',
-        'maxFreeSockets', 'passphrase', 'pfx', 'rejectUnauthorized',
-        'secureProtocol', 'timeout', 'maxCachedSessions'
+        'keepAliveMsecs', 'maxFreeSockets', 'maxSockets', 'maxTotalSockets', 'scheduling', 'timeout'
       ]);
       connectionParams.agent = new http.Agent(agentOptions);
     } else {

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -718,7 +718,12 @@ MarkLogicClient.prototype.createProxy = function createProxy(serviceDeclaration)
 
 function initClient(client, inputParams) {
   var connectionParams = {};
+  var isSSL = (inputParams.ssl == null) ? false : inputParams.ssl;
   var keys = ['host', 'port', 'database', 'user', 'password', 'authType', 'token'];
+  if(isSSL) {
+    keys.push('ca', 'cert', 'ciphers', 'clientCertEngine', 'crl', 'dhparam', 'ecdhCurve', 'honorCipherOrder', 'key', 'passphrase',
+        'pfx', 'rejectUnauthorized', 'secureOptions', 'secureProtocol', 'servername', 'sessionIdContext', 'highWaterMark');
+  }
   for (var i=0; i < keys.length; i++) {
     var key = keys[i];
     var value = inputParams[key];
@@ -765,9 +770,6 @@ function initClient(client, inputParams) {
       connectionParams.user+':'+connectionParams.password;
   }
 
-  var isSSL = (inputParams.ssl == null) ?
-    false : inputParams.ssl;
-
   var noAgent = (inputParams.agent == null);
   var agentOptions = noAgent ? {
     keepAlive: true
@@ -776,9 +778,8 @@ function initClient(client, inputParams) {
     client.request = https.request;
     if (noAgent) {
       mlutil.copyProperties(inputParams, agentOptions, [
-        'ca', 'cert', 'ciphers', 'keepAliveMsecs', 'key', 'maxSockets',
-        'maxFreeSockets', 'passphrase', 'pfx', 'rejectUnauthorized',
-        'secureProtocol', 'timeout'
+        'keepAliveMsecs', 'maxSockets', 'maxTotalSockets',
+        'maxFreeSockets', 'timeout', 'scheduling'
       ]);
       connectionParams.agent = new https.Agent(agentOptions);
     } else {
@@ -788,7 +789,9 @@ function initClient(client, inputParams) {
     client.request = http.request;
     if (noAgent) {
       mlutil.copyProperties(inputParams, agentOptions, [
-        'keepAliveMsecs', 'maxSockets', 'maxFreeSockets', 'timeout'
+        'ca', 'cert', 'ciphers', 'keepAliveMsecs', 'key', 'maxSockets',
+        'maxFreeSockets', 'passphrase', 'pfx', 'rejectUnauthorized',
+        'secureProtocol', 'timeout', 'maxCachedSessions'
       ]);
       connectionParams.agent = new http.Agent(agentOptions);
     } else {


### PR DESCRIPTION
rejectUnauthorized option ignored in webpacked typescript (impacts mlxprs extension in latest VSCode on Mac)
Fix for issue - https://github.com/marklogic/node-client-api/issues/568