### PR TITLE
NODE-72: Include examples for transformAll and queryToTransformAll.

### DIFF
--- a/examples/queryToTransformAll-documents.js
+++ b/examples/queryToTransformAll-documents.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const exutil = require('./example-util.js');
+const marklogic = exutil.require('marklogic');
+const ctsQb = marklogic.ctsQueryBuilder;
+const q = marklogic.queryBuilder;
+const dbWriter = marklogic.createDatabaseClient(exutil.restWriterConnection);
+const transformName = 'Name_of_transform_in_the_database';
+
+console.log('This example uses queryToTransformAll api to apply a transform to a set of documents that are already in ' +
+    'the database. The transform used to configure the documents must be installed on the server beforehand. ' +
+    'The documents(s) are the ones that fall under the cts query given as input.');
+
+// Directory query to collect documents in the specified directory.
+const query = q.where(ctsQb.cts.directoryQuery('/test/dataMovement/requests/transformAll/'));
+
+dbWriter.documents.queryToTransformAll(query,{
+    transform: [transformName, {'field_in_the_document':'Transformation_needed'}],
+    onCompletion:((summary) => {
+        console.log(summary.docsTransformedSuccessfully+' documents were transformed successfully.');
+        console.log(summary.docsFailedToBeTransformed+' documents failed to be transformed.');
+        console.log('Time taken was '+summary.timeElapsed+' milliseconds.');
+    })
+});

--- a/examples/transformAll-documents.js
+++ b/examples/transformAll-documents.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const exutil = require('./example-util.js');
+const marklogic = require('../');
+const dbWriter = marklogic.createDatabaseClient(exutil.restWriterConnection);
+const transformName = 'Name_of_transform_in_the_database';
+
+console.log('This example applies a transform to a set of documents that are already in the database.' +
+    ' The transform used to configure the documents must be installed on the server beforehand.');
+
+const Stream = require('stream');
+let transformStream = new Stream.PassThrough({objectMode: true});
+
+for(let i=0; i<100; i++) {
+    const documentUri = '/test/dataMovement/requests/transformAll/'+i+'.json';
+    transformStream.push(documentUri);
+}
+transformStream.push(null);
+
+transformStream.pipe(dbWriter.documents.transformAll({
+    transform: [transformName, {'field_in_the_document':'Transformation_needed'}],
+    onCompletion: ((summary) => {
+        console.log(summary.docsTransformedSuccessfully+' documents were transformed successfully.');
+        console.log(summary.docsFailedToBeTransformed+' documents failed to be transformed.');
+        console.log('Time taken was '+summary.timeElapsed+' milliseconds.');
+    })
+}));

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1937,7 +1937,7 @@ function queryDocumentsImpl(collectionParam, contentOnly, builtQuery, timestamp,
   }
   if (!returnDocuments) {
     operation.outputTransform = listOutputTransform;
-  }else if(resultEstimateCallback) {
+  } else if (resultEstimateCallback) {
     operation.resultEstimateCallback = resultEstimateCallback;
     operation.onMultipart = multipartTransform;
   }

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -95,7 +95,7 @@ function responseDispatcher(response) {
       operation.logger.debug('expected body but received multipart');
     }
 
-    if(operation.onMultipart){
+    if (operation.onMultipart){
       operation.onMultipart(response.headers);
     }
 


### PR DESCRIPTION
1. https://github.com/marklogic/node-client-api/issues/644 - Adding example for transformAll and queryToTransformAll in the examples folder.
2. Indentation fixes for - https://github.com/marklogic/node-client-api/pull/666