### PR TITLE
DEVEXP-72: Upgrade dependencies in Node-client version 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "concat-stream": "^2.0.0",
     "deepcopy": "^2.1.0",
-    "dicer": "^0.3.1",
+    "dicer": "^0.3.0",
     "duplexify": "^4.1.2",
     "json-text-sequence": "^1.0.1",
     "multipart-stream": "^2.0.1",


### PR DESCRIPTION
The tests are working fine:    973 passing (3m)

But the "dicer" package is not solvable because has no good version.

https://github.com/advisories/GHSA-wm7h-9275-46v2

![image](https://user-images.githubusercontent.com/104991743/195040654-80b949e8-a697-464e-82f2-193711749cf6.png)



