### PR TITLE
Node-89 : MarkLogic module v 2.9.1 for Node.js at Windows OS does not work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ using [npm](https://www.npmjs.com/package/marklogic):
 npm install marklogic --save
 ```
 
+For Windows OS please use the below for Node Client 2.9.1:
+```
+npm install marklogic --save --ignore-scripts
+```
+
 With the marklogic package installed, the following inserts two documents in a
 collection into the Documents database using MarkLogic's built-in REST server
 at port 8000:


### PR DESCRIPTION
Updating README for - https://github.com/marklogic/node-client-api/issues/694 