### PR TITLE
DEVO-762 Changes to remove QA test error

### DIFF
--- a/test-complete-proxy/nodejs-ds-error-map.js
+++ b/test-complete-proxy/nodejs-ds-error-map.js
@@ -93,7 +93,6 @@ describe('Error-Map-Test', function(){
           expect(errMapResp.messageDetail.messageTitle).to.contain('MLQA-ERROR-2');
           done();
         });
-	done();
 	});
 	
 	it('Valid return and Error mapping 2', function(done){


### PR DESCRIPTION
A one line change to make tests run without error in Node JS ver. 18.14.2