### PR TITLE
Fix the transaction time limit test

### DIFF
--- a/test-complete/nodejs-documents-transaction-timelimit.js
+++ b/test-complete/nodejs-documents-transaction-timelimit.js
@@ -20,78 +20,103 @@ var testconfig = require('../etc/test-config-qa.js');
 var marklogic = require('../');
 
 var db = marklogic.createDatabaseClient(testconfig.restWriterConnection);
-var dbReader = marklogic.createDatabaseClient(testconfig.restReaderConnection);
 var dbAdmin = marklogic.createDatabaseClient(testconfig.restAdminConnection);
-var tid = null;
 
-describe('Document transaction test', function () {
+function delay(t, val) {
+    return new Promise(resolve => setTimeout(resolve, t, val));
+}
+
+describe('Document transaction timelimit test', function () {
+
+    after('should remove all documents', function (done) {
+        dbAdmin.documents.removeAll({ all: true })
+            .result(function (response) {
+                done();
+            });
+    });
 
     var tid = 0;
-    it('should commit the write document', function (done) {
+    it('Uncommitted transactions should timeout', function (done) {
+        this.timeout(20000);
+        // Start a transaction
         db.transactions.open({ transactionName: 'nodeTransaction', timeLimit: 3 })
             .result(function (response) {
                 tid = response.txid;
+                // Write a document as part of the transaction
                 return db.documents.write({
                     txid: tid,
                     uri: '/test/transaction/doc1.json',
                     contentType: 'application/json',
                     content: { firstname: 'John', lastname: 'Doe', txKey: tid }
-                }).result();
+                })
+                    .result(
+                        function (response) {
+                            return response;
+                        },
+                        function (err) {
+                            console.error('Failed to write document in transaction');
+                            done(err);
+                        }
+                    );
             })
             .then(function (response) {
-                //console.log(JSON.stringify(response, null, 2));
                 response.documents[0].uri.should.equal('/test/transaction/doc1.json');
-                return db.transactions.read(tid).result();
+                // Get the status of the transaction
+                return db.transactions.read(tid)
+                    .result(
+                        function (response) {
+                            return response;
+                        },
+                        function (err) {
+                            console.error('Failed to read transaction state');
+                        }
+                    );
             })
             .then(function (response) {
-                //console.log(JSON.stringify(response, null, 2));
                 response['transaction-status']['transaction-name'].should.equal('nodeTransaction');
                 parseInt(response['transaction-status']['time-limit']).should.be.above(0);
-                done();
-            }).catch(error => done(error));
-
-    });
-
-    // Wait for 3 seconds so that transaction can time out
-    it('should wait for 3 seconds', function (done) {
-        this.timeout(4000);
-        setTimeout(function () {
-            done();
-
-        }, 3000);
-    });
-
-    it('should read the commited document and fail with 400/XDMP-NOTXN error (transaction timed out)', function (done) {
-        db.documents.read({ uris: '/test/transaction/doc1.json', txid: tid, }).result(function (response) {
-            console.log('Response: ' + JSON.stringify(response));
-            done(new Error('Response did not time out'));
-        },
-        function (err) {
-            err.statusCode.should.equal(400);
-            err.body.errorResponse.messageCode.should.equal('XDMP-NOTXN');
-            done();
-        }).catch(error => done(error));
-    });
-
-    it('should commit the document', function (done) {
-        db.transactions.commit(tid).
-            result(
-                function (response) {
-                    console.log('Response: ' + JSON.stringify(response));
-                    done(new Error('Response did not time out'));
-                },
-                function (err) {
-                    err.statusCode.should.equal(400);
-                    err.body.errorResponse.messageCode.should.equal('XDMP-NOTXN');
-                    done();
-                })
-            .catch(error => done(error));
-    });
-
-    it('should remove all documents', function (done) {
-        dbAdmin.documents.removeAll({ all: true }).
-            result(function (response) {
-                done();
-            }).catch(error => done(error));
+            })
+            .then(() => {
+                // Attempt to read document using the transaction ID (it should succeed)
+                return db.documents.read({ uris: '/test/transaction/doc1.json', txid: tid, })
+                    .result(
+                        function (response) {
+                            response[0].uri.should.equal('/test/transaction/doc1.json');
+                        },
+                        function (err) {
+                            done(err);
+                        }
+                    );
+            })
+            .then(() => {
+                // Wait for the transaction to timeout
+                return delay(4000);
+            })
+            .then(() => {
+                // Attempt to read document using the transaction ID (it should fail)
+                return db.documents.read({ uris: '/test/transaction/doc1.json', txid: tid, })
+                    .result(
+                        function (response) {
+                            done(new Error('The read should fail since the transaction should have timed out.'));
+                        },
+                        function (err) {
+                            err.statusCode.should.equal(400);
+                            err.body.errorResponse.messageCode.should.equal('XDMP-NOTXN');
+                        }
+                    );
+            })
+            .then(() => {
+                // Attempt to check the transaction status again (it should fail)
+                return db.transactions.commit(tid)
+                    .result(
+                        function (response) {
+                            done(new Error('The transaction status check should fail since the transaction should have timed out.'));
+                        },
+                        function (err) {
+                            err.statusCode.should.equal(400);
+                            err.body.errorResponse.messageCode.should.equal('XDMP-NOTXN');
+                            done();
+                        });
+            });
     });
 });


### PR DESCRIPTION
Mocha does not guarantee "it" blocks are run sequentially or that they are non-synchronous.
Therefore, this "set" of tests really needs to be a single test with a chain of promises in order to guarantee order and timing.
