### PR TITLE
Unparallelize Mocha tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ def runE2ETests(String type,String version){
         cd test-complete-app
         ./gradlew -i mlDeploy
         cd ..
-        ./node_modules/.bin/mocha -R xunit --timeout 60000  test-complete/ --reporter mocha-junit-reporter --reporter-options mochaFile=$WORKSPACE/test-complete-results.xml  || true
+        ./node_modules/.bin/mocha --no-parallel -R xunit --timeout 60000  test-complete/ --reporter mocha-junit-reporter --reporter-options mochaFile=$WORKSPACE/test-complete-results.xml  || true
         cd test-complete-proxy
         npm install --global gulp-cli
         gulp loadToModulesDB

--- a/test-complete/nodejs-dmsdk-queryall.js
+++ b/test-complete/nodejs-dmsdk-queryall.js
@@ -82,16 +82,10 @@ describe('queryAll-tests-1', function () {
         this.timeout(10000);
         const fileName1 = path.join(__dirname, '/data/dmsdk/queryAllColl.txt');
         const fileName2 = path.join(__dirname, '/data/dmsdk/queryAllOneResult.txt');
-        fs.unlink(fileName1, function (err) {
-            if (err) {
-                done(err);
-            }
-        });
-        fs.unlink(fileName2, function (err) {
-            if (err) {
-                done(err);
-            }
-        });
+        try {
+            fs.unlink(fileName1, function (err) {});
+            fs.unlink(fileName2, function (err) {});
+        } catch (err) {}
         done();
     });
 
@@ -247,7 +241,9 @@ describe('queryAll-tests-2', function () {
     after(function (done) {
         this.timeout(10000);
         const fileNameMB = path.join(__dirname, '/data/dmsdk/queryAllMBResult.txt');
-        fs.unlinkSync(fileNameMB);
+        try {
+            fs.unlinkSync(fileNameMB);
+        } catch (err) {}
         done();
     });
 


### PR DESCRIPTION
It seems like some of the mocha tests have unintended interactions. So, this should ensure that the test files are run one at a time.

Also, surrounded some cleanup code with a try-catch block for when the test fails and nothing is there to clean up.
