### PR TITLE
MLE-24312: fix ssl tests

### DIFF
--- a/test-app/docker-compose-nightlies.yaml
+++ b/test-app/docker-compose-nightlies.yaml
@@ -22,6 +22,6 @@ services:
     volumes:
       - ./containerLogs:/var/opt/MarkLogic/Logs
     ports:
-      - 8000-8016:8000-8016
+      - 8000-8017:8000-8017
       - 8024-8029:8024-8029
       - 8079:8079

--- a/test-app/docker-compose.yaml
+++ b/test-app/docker-compose.yaml
@@ -15,4 +15,4 @@ services:
       - ./docker/marklogic/logs:/var/opt/MarkLogic/Logs
     ports:
       - 8000-8002:8000-8002
-      - 8015-8016:8015-8016
+      - 8015-8017:8015-8017

--- a/test-basic/client.js
+++ b/test-basic/client.js
@@ -146,7 +146,8 @@ describe('database clients', function () {
         .result()
         .catch(error => {
           try{
-            assert(error.message.toString().includes('You have attempted to access an HTTP server using HTTPS. Please check your configuration.'));
+            assert(error.message.toString().includes('You have attempted to access an HTTP server using HTTPS. Please check your configuration.') ||
+                   error.message.toString().includes('write EPROTO'));
             done();
           } catch(err){
             done(err);


### PR DESCRIPTION
Fix SSL tests by exposing port 8017 in docker-compose files and adding new matching error message text in the SSL to non-SSL REST service test assert call.