### PR TITLE
MLE-24397 - fix reported issue on Linux FIPS around exception caused by default load of FIPS-forbidden MD5 digest algorithm. Incorporate the source from the abandoned www-authenticate project and fix in place.

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -2,7 +2,7 @@
 * Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 'use strict';
-var createAuthInitializer = require('./www-authenticate/www-authenticate');
+var createAuthInitializer = require('./www-authenticate-patched/www-authenticate');
 var Kerberos              = require('./optional.js')
                             .libraryProperty('kerberos', 'Kerberos');
 var Multipart             = require('multipart-stream');

--- a/lib/www-authenticate-patched/md5.js
+++ b/lib/www-authenticate-patched/md5.js
@@ -1,6 +1,15 @@
-var crypto= require('crypto')
-  , md5sum = crypto.createHash('md5')
-  ;
+/*
+ * www-authenticate
+ * https://github.com/randymized/www-authenticate
+ *
+ * Copyright (c) 2013 Randy McLaughlin
+ * Licensed under the MIT license.
+ */
+
+/*
+* Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+*/
+var crypto= require('crypto');
 
 function md5(s) {
   return crypto.createHash('md5').update(s).digest('hex');

--- a/lib/www-authenticate-patched/md5.js
+++ b/lib/www-authenticate-patched/md5.js
@@ -1,4 +1,6 @@
-var crypto= require('crypto');
+var crypto= require('crypto')
+  , md5sum = crypto.createHash('md5')
+  ;
 
 function md5(s) {
   return crypto.createHash('md5').update(s).digest('hex');

--- a/lib/www-authenticate-patched/parsers.js
+++ b/lib/www-authenticate-patched/parsers.js
@@ -1,3 +1,14 @@
+/*
+ * www-authenticate
+ * https://github.com/randymized/www-authenticate
+ *
+ * Copyright (c) 2013 Randy McLaughlin
+ * Licensed under the MIT license.
+ */
+
+/*
+* Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+*/
 var ParseAuth= /(\w+)\s+(.*)/  // -> scheme, params
   , Separators= /([",=])/
   ;
@@ -88,8 +99,6 @@ function Parse_WWW_Authenticate(to_parse)
   }
 }
 
-Parse_Authentication_Info.prototype.parse_params= parse_params;
-
 function Parse_Authentication_Info(to_parse)
 {
   this.scheme= 'Digest';
@@ -102,6 +111,7 @@ function Parse_Authentication_Info(to_parse)
   }
 }
 
+Parse_Authentication_Info.prototype.parse_params= parse_params;
 Parse_WWW_Authenticate.prototype.parse_params= parse_params;
 
 module.exports = {

--- a/lib/www-authenticate-patched/parsers.js
+++ b/lib/www-authenticate-patched/parsers.js
@@ -88,6 +88,8 @@ function Parse_WWW_Authenticate(to_parse)
   }
 }
 
+Parse_Authentication_Info.prototype.parse_params= parse_params;
+
 function Parse_Authentication_Info(to_parse)
 {
   this.scheme= 'Digest';
@@ -100,7 +102,6 @@ function Parse_Authentication_Info(to_parse)
   }
 }
 
-Parse_Authentication_Info.prototype.parse_params= parse_params;
 Parse_WWW_Authenticate.prototype.parse_params= parse_params;
 
 module.exports = {

--- a/lib/www-authenticate-patched/user-credentials.js
+++ b/lib/www-authenticate-patched/user-credentials.js
@@ -1,3 +1,14 @@
+/*
+ * www-authenticate
+ * https://github.com/randymized/www-authenticate
+ *
+ * Copyright (c) 2013 Randy McLaughlin
+ * Licensed under the MIT license.
+ */
+
+/*
+* Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+*/
 var md5= require('./md5');
 
 /*
@@ -16,9 +27,9 @@ function user_credentials(username,password,options) {
     ''
     :
       (!password && password !== '' ?
-        new Buffer(username, "ascii").toString("base64")
+        Buffer.from(username, "ascii").toString("base64")
       :
-        new Buffer(username+':'+password, "ascii").toString("base64")
+        Buffer.from(username+':'+password, "ascii").toString("base64")
       )
   function Credentials()
   {

--- a/lib/www-authenticate-patched/user-credentials.js
+++ b/lib/www-authenticate-patched/user-credentials.js
@@ -16,9 +16,9 @@ function user_credentials(username,password,options) {
     ''
     :
       (!password && password !== '' ?
-        Buffer.from(username, "ascii").toString("base64")
+        new Buffer(username, "ascii").toString("base64")
       :
-        Buffer.from(username+':'+password, "ascii").toString("base64")
+        new Buffer(username+':'+password, "ascii").toString("base64")
       )
   function Credentials()
   {

--- a/lib/www-authenticate-patched/www-authenticate.js
+++ b/lib/www-authenticate-patched/www-authenticate.js
@@ -1,4 +1,3 @@
-
 /*
  * www-authenticate
  * https://github.com/randymized/www-authenticate
@@ -7,10 +6,12 @@
  * Licensed under the MIT license.
  */
 
+/*
+* Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+*/
 'use strict';
 
 var crypto= require('crypto')
-  , md5sum = crypto.createHash('md5')
   , parsers= require('./parsers')
   , md5= require('./md5')
   , user_credentials= require('./user-credentials')

--- a/lib/www-authenticate-patched/www-authenticate.js
+++ b/lib/www-authenticate-patched/www-authenticate.js
@@ -1,3 +1,4 @@
+
 /*
  * www-authenticate
  * https://github.com/randymized/www-authenticate
@@ -6,13 +7,10 @@
  * Licensed under the MIT license.
  */
 
-/*
-* Copyright © 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
-*/
-
 'use strict';
 
 var crypto= require('crypto')
+  , md5sum = crypto.createHash('md5')
   , parsers= require('./parsers')
   , md5= require('./md5')
   , user_credentials= require('./user-credentials')
@@ -42,20 +40,6 @@ var www_authenticator = function(username,password,options)
       cnonce= options.cnonce;
   }
   if (cnonce === void 0) cnonce= crypto.pseudoRandomBytes(8).toString('hex');
-
-  /**
-   * @typedef {Object} Authenticator
-   * @property {any} [err]
-   * @property {function(string=, string=): string} [authorize]
-   * @property {any} [parms]
-   * @property {string} [cnonce]
-   */
-
-  /**
-   * Parses the WWW-Authenticate header.
-   * @param {string} www_authenticate
-   * @returns {Authenticator}
-   */
   var parse_header= function(www_authenticate)
   {
     function Authenticator()

--- a/test-basic/digestauth-fips-nomd5load.js
+++ b/test-basic/digestauth-fips-nomd5load.js
@@ -22,8 +22,8 @@ describe('FIPS test - ensure MD5 hash digester object is not loaded by default o
      * To simulate the require/load, we first delete the module from Node's require cache
      * and then require it again, which forces a reload of the module.
      */
-    delete require.cache[require.resolve('../lib/www-authenticate/www-authenticate')];
-    delete require.cache[require.resolve('../lib/www-authenticate/md5')];
+    delete require.cache[require.resolve('../lib/www-authenticate-patched/www-authenticate')];
+    delete require.cache[require.resolve('../lib/www-authenticate-patched/md5')];
     const crypto = require('crypto');
     const originalCreateHash = crypto.createHash;
 
@@ -40,8 +40,8 @@ describe('FIPS test - ensure MD5 hash digester object is not loaded by default o
       (() => crypto.createHash('md5')).should.throw('FIPS emulation: MD5 digest algorithm is not allowed on this system!');
 
       // Require the module - should not call to get MD5 digester so should not throw
-      (() => require('../lib/www-authenticate/md5')).should.not.throw();
-      (() => require('../lib/www-authenticate/www-authenticate')).should.not.throw();
+      (() => require('../lib/www-authenticate-patched/md5')).should.not.throw();
+      (() => require('../lib/www-authenticate-patched/www-authenticate')).should.not.throw();
 
     } finally {
       // Restore the original createHash function to avoid side effects


### PR DESCRIPTION
MLE-24397 - fix reported issue on Linux FIPS around exception caused by default load of FIPS-forbidden MD5 digest algorithm. Incorporate the source from the abandoned www-authenticate project and fix in place.