### PR TITLE
MLE-25579 Can now specify transform params when writing a transform

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -80,6 +80,8 @@ Transforms.prototype.read = function readTransform(name) {
  * @param {string} name - the name of the transform
  * @param {string} format - a value from the javascript|xquery|xslt enumeration
  * @param {object|string} source - the source for the transform
+ * @param {object} [transformParams] - an object mapping parameter names to their
+ * XQuery SequenceType declarations (including cardinality such as *, ?, etc.)
  */
 Transforms.prototype.write = function writeTransform() {
   const args = mlutil.asArray.apply(null, arguments);
@@ -88,24 +90,26 @@ Transforms.prototype.write = function writeTransform() {
     throw new Error('no arguments for writing an extension library');
   }
 
-  let name        = null;
-  let title       = null;
-  let description = null;
-  let provider    = null;
-  let version     = null;
-  let format      = null;
-  let source      = null;
+  let name            = null;
+  let title           = null;
+  let description     = null;
+  let provider        = null;
+  let version         = null;
+  let format          = null;
+  let source          = null;
+  let transformParams = null;
 
   let params      = null;
   if (argLen === 1) {
     params = args[0];
-    name        = params.name;
-    title       = params.title;
-    description = params.description;
-    provider    = params.provider;
-    version     = params.version;
-    format      = params.format;
-    source      = params.source;
+    name            = params.name;
+    title           = params.title;
+    description     = params.description;
+    provider        = params.provider;
+    version         = params.version;
+    format          = params.format;
+    source          = params.source;
+    transformParams = params.transformParams;
   } else if (argLen > 2){
     name   = args[0];
     format = args[1];
@@ -150,6 +154,13 @@ Transforms.prototype.write = function writeTransform() {
   if (version != null) {
     endpoint += sep+'version='+encodeURIComponent(version);
     if (sep === '?') {sep = '&';}
+  }
+
+  if (transformParams != null) {
+    for (const [paramName, paramType] of Object.entries(transformParams)) {
+      endpoint += sep+'trans:'+encodeURIComponent(paramName)+'='+encodeURIComponent(paramType);
+      if (sep === '?') {sep = '&';}
+    }
   }
 
   const requestOptions = mlutil.copyProperties(this.client.getConnectionParams());

--- a/test-basic/documents-transform.js
+++ b/test-basic/documents-transform.js
@@ -26,6 +26,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should write the transform with named parameters', function(done){
       this.timeout(3000);
       restAdminDB.config.transforms.write({
@@ -35,13 +36,18 @@ describe('document transform', function(){
         provider:    'Banner Business',
         version:     0.1,
         format:      'xquery',
-        source:      fs.createReadStream(xqyTransformPath)
+        source:      fs.createReadStream(xqyTransformPath),
+        transformParams: {
+          'flag': 'xs:string?',
+          'count': 'xs:integer*'
+        }
         })
       .result(function(response){
         done();
         })
       .catch(done);
     });
+
     it('should read the transform', function(done){
       restAdminDB.config.transforms.read(xqyTransformName)
       .result(function(source){
@@ -51,19 +57,35 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should list the transform', function(done){
       db.config.transforms.list()
       .result(function(response){
         response.should.have.property('transforms');
         response.transforms.should.have.property('transform');
         response.transforms.transform.length.should.be.greaterThan(0);
-        response.transforms.transform.some(function(item){
+
+        const flagTransform = response.transforms.transform.find(function(item){
           return item.name === xqyTransformName;
-          }).should.equal(true);
+        });
+        should.exist(flagTransform);
+        flagTransform.should.have.property('transform-parameters');
+        flagTransform['transform-parameters'].should.have.property('parameter');
+
+        const params = flagTransform['transform-parameters'].parameter;
+        params.should.be.an.Array();
+        params.length.should.equal(2);
+        params.some(function(p){
+          return p['parameter-name'] === 'flag' && p['parameter-type'] === 'xs:string?';
+        }).should.equal(true);
+        params.some(function(p){
+          return p['parameter-name'] === 'count' && p['parameter-type'] === 'xs:integer*';
+        }).should.equal(true);
         done();
-        })
+      })
       .catch(done);
     });
+
     it('should delete the transform', function(done){
       restAdminDB.config.transforms.remove(xqyTransformName)
       .result(function(response){
@@ -83,6 +105,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should modify during write', function(done){
       db.documents.write({
         uri: uri,
@@ -100,6 +123,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should modify during read', function(done){
       db.documents.read({
         uris: uri,
@@ -112,6 +136,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should modify during query', function(done){
       db.documents.query(
           q.where(
@@ -147,6 +172,7 @@ describe('document transform', function(){
       .then(function(response){done();})
       .catch(done);
     });
+
     it('should modify during write', function(done){
       db.documents.write({
         uri: writeUri,
@@ -166,6 +192,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should modify during read', function(done){
       db.documents.read({
         uris: readUri,
@@ -180,6 +207,7 @@ describe('document transform', function(){
         })
       .catch(done);
     });
+
     it('should modify during query', function(done){
       db.documents.query(
           q.where(


### PR DESCRIPTION
When transforms did lack the power to declare
What parameters they would deign to receive,
Developers were left in dark despair,
With undocumented args they could not believe.

But lo! transformParams now graces the write,
A simple object of name and type pairs,
From xs:string? to xs:integer's might,
The query string now carries all affairs.

trans:flag and trans:count now ride along,
URL-encoded, proper, clean, and true,
The list endpoint sings a validating song,
Confirming params registered on cue.

So merge this branch with confidence and cheer,
For typed transform params are finally here!
