### PR TITLE
PDP-1182 SECCMP-1797: Add top-level permissions to restrict default token

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,18 +1,17 @@
 name: PR Workflow
 
 on:
-  # Using pull_request_target instead of pull_request to handle PRs from forks
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
-    # No branch filtering - will run on all PRs
+
+permissions:
+  contents: read
 
 jobs:
   jira-pr-check:
     name: 🏷️ Validate JIRA ticket ID
-    # Use the reusable workflow from the central repository
     uses: marklogic/pr-workflows/.github/workflows/jira-id-check.yml@main
     with:
-      # Pass the PR title from the event context
       pr-title: ${{ github.event.pull_request.title }}
   copyright-validation:
     name: © Validate Copyright Headers


### PR DESCRIPTION
## SECCMP-1797: Add top-level permissions to restrict default token

Adds `permissions: contents: read` at the workflow level to restrict the default GITHUB_TOKEN scope. Without this, all jobs inherit the full `pull_request_target` write token.

The `copyright-validation` job already declares its own `permissions` block which overrides the default for that specific job.

Ref: [Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)