### PR TITLE
MLE-27883 adapt cts.param in the Optic API for MLS 12.1

### DIFF
--- a/lib/plan-builder-generated.js
+++ b/lib/plan-builder-generated.js
@@ -210,7 +210,7 @@ circleRadius(...args) {
     * @returns { CtsQuery }
     */
 collectionQuery(...args) {
-    const paramdef = ['uris', [types.XsString], false, true];
+    const paramdef = ['uris', [types.XsString, types.CtsParam], false, true];
     const checkedArgs = bldrbase.makeSingleArgs('cts.collectionQuery', 1, paramdef, args);
     return new types.CtsQuery('cts', 'collection-query', checkedArgs);
     }
@@ -241,7 +241,7 @@ collectionReference(...args) {
     */
 columnRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'schema');
-    const paramdefs = [['schema', [types.XsString], true, false], ['view', [types.XsString], true, false], ['column', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['operator', [types.XsString], false, false], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['schema', [types.XsString], true, false], ['view', [types.XsString], true, false], ['column', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['operator', [types.XsString], false, false], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.columnRangeQuery', 4, new Set(['schema', 'view', 'column', 'value', 'operator', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.columnRangeQuery', 4, false, paramdefs, args);
@@ -275,7 +275,7 @@ complexPolygon(...args) {
     */
 directoryQuery(...args) {
     const namer = bldrbase.getNamer(args, 'uris');
-    const paramdefs = [['uris', [types.XsString], false, true], ['depth', [types.XsString], false, false]];
+    const paramdefs = [['uris', [types.XsString, types.CtsParam], false, true], ['depth', [types.XsString], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.directoryQuery', 1, new Set(['uris', 'depth']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.directoryQuery', 1, false, paramdefs, args);
@@ -331,7 +331,7 @@ documentPermissionQuery(...args) {
     * @returns { CtsQuery }
     */
 documentQuery(...args) {
-    const paramdef = ['uris', [types.XsString], false, true];
+    const paramdef = ['uris', [types.XsString, types.CtsParam], false, true];
     const checkedArgs = bldrbase.makeSingleArgs('cts.documentQuery', 1, paramdef, args);
     return new types.CtsQuery('cts', 'document-query', checkedArgs);
     }
@@ -382,7 +382,7 @@ elementAttributePairGeospatialQuery(...args) {
     */
 elementAttributeRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementAttributeRangeQuery', 4, new Set(['element-name', 'attribute-name', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementAttributeRangeQuery', 4, false, paramdefs, args);
@@ -420,7 +420,7 @@ elementAttributeReference(...args) {
     */
 elementAttributeValueQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementAttributeValueQuery', 3, new Set(['element-name', 'attribute-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementAttributeValueQuery', 3, false, paramdefs, args);
@@ -440,7 +440,7 @@ elementAttributeValueQuery(...args) {
     */
 elementAttributeWordQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['attribute-name', [types.XsQName], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementAttributeWordQuery', 3, new Set(['element-name', 'attribute-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementAttributeWordQuery', 3, false, paramdefs, args);
@@ -537,7 +537,7 @@ elementQuery(...args) {
     */
 elementRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementRangeQuery', 3, new Set(['element-name', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementRangeQuery', 3, false, paramdefs, args);
@@ -573,7 +573,7 @@ elementReference(...args) {
     */
 elementValueQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementValueQuery', 1, new Set(['element-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementValueQuery', 1, false, paramdefs, args);
@@ -592,7 +592,7 @@ elementValueQuery(...args) {
     */
 elementWordQuery(...args) {
     const namer = bldrbase.getNamer(args, 'element-name');
-    const paramdefs = [['element-name', [types.XsQName], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['element-name', [types.XsQName], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.elementWordQuery', 2, new Set(['element-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.elementWordQuery', 2, false, paramdefs, args);
@@ -623,7 +623,7 @@ falseQuery(...args) {
     */
 fieldRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'field-name');
-    const paramdefs = [['field-name', [types.XsString], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['field-name', [types.XsString, types.CtsParam], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.fieldRangeQuery', 3, new Set(['field-name', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.fieldRangeQuery', 3, false, paramdefs, args);
@@ -659,7 +659,7 @@ fieldReference(...args) {
     */
 fieldValueQuery(...args) {
     const namer = bldrbase.getNamer(args, 'field-name');
-    const paramdefs = [['field-name', [types.XsString], false, true], ['text', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['field-name', [types.XsString, types.CtsParam], false, true], ['text', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.fieldValueQuery', 2, new Set(['field-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.fieldValueQuery', 2, false, paramdefs, args);
@@ -678,7 +678,7 @@ fieldValueQuery(...args) {
     */
 fieldWordQuery(...args) {
     const namer = bldrbase.getNamer(args, 'field-name');
-    const paramdefs = [['field-name', [types.XsString], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['field-name', [types.XsString, types.CtsParam], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.fieldWordQuery', 2, new Set(['field-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.fieldWordQuery', 2, false, paramdefs, args);
@@ -828,7 +828,7 @@ jsonPropertyPairGeospatialQuery(...args) {
     */
 jsonPropertyRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'property-name');
-    const paramdefs = [['property-name', [types.XsString], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['property-name', [types.XsString, types.CtsParam], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.jsonPropertyRangeQuery', 3, new Set(['property-name', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.jsonPropertyRangeQuery', 3, false, paramdefs, args);
@@ -881,7 +881,7 @@ jsonPropertyScopeQuery(...args) {
     */
 jsonPropertyValueQuery(...args) {
     const namer = bldrbase.getNamer(args, 'property-name');
-    const paramdefs = [['property-name', [types.XsString], false, true], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['property-name', [types.XsString, types.CtsParam], false, true], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.jsonPropertyValueQuery', 2, new Set(['property-name', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.jsonPropertyValueQuery', 2, false, paramdefs, args);
@@ -900,7 +900,7 @@ jsonPropertyValueQuery(...args) {
     */
 jsonPropertyWordQuery(...args) {
     const namer = bldrbase.getNamer(args, 'property-name');
-    const paramdefs = [['property-name', [types.XsString], false, true], ['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['property-name', [types.XsString, types.CtsParam], false, true], ['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.jsonPropertyWordQuery', 2, new Set(['property-name', 'text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.jsonPropertyWordQuery', 2, false, paramdefs, args);
@@ -1059,7 +1059,7 @@ pathGeospatialQuery(...args) {
     */
 pathRangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'path-name');
-    const paramdefs = [['path-name', [types.XsString], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['path-name', [types.XsString, types.CtsParam], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.pathRangeQuery', 3, new Set(['path-name', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.pathRangeQuery', 3, false, paramdefs, args);
@@ -1219,7 +1219,7 @@ propertiesFragmentQuery(...args) {
     */
 rangeQuery(...args) {
     const namer = bldrbase.getNamer(args, 'index');
-    const paramdefs = [['index', [types.CtsReference], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['index', [types.CtsReference], false, true], ['operator', [types.XsString], true, false], ['value', [types.XsAnyAtomicType, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.rangeQuery', 3, new Set(['index', 'operator', 'value', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.rangeQuery', 3, false, paramdefs, args);
@@ -1316,7 +1316,7 @@ uriReference(...args) {
     */
 wordQuery(...args) {
     const namer = bldrbase.getNamer(args, 'text');
-    const paramdefs = [['text', [types.XsString], false, true], ['options', [types.XsString], false, true], ['weight', [types.XsDouble], false, false]];
+    const paramdefs = [['text', [types.XsString, types.CtsParam], false, true], ['options', [types.XsString, types.CtsParam], false, true], ['weight', [types.XsDouble], false, false]];
     const checkedArgs = (namer !== null) ?
         bldrbase.makeNamedArgs(namer, 'cts.wordQuery', 1, new Set(['text', 'options', 'weight']), paramdefs, args) :
         bldrbase.makePositionalArgs('cts.wordQuery', 1, false, paramdefs, args);

--- a/lib/plan-builder.js
+++ b/lib/plan-builder.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 'use strict';
 

--- a/lib/plan-builder.js
+++ b/lib/plan-builder.js
@@ -66,6 +66,12 @@ bldrgen.AccessPlan.prototype.col = function(...args) {
   return new bldrgen.PlanColumn('op', 'col', checkedArgs);
 };
 
+bldrgen.CtsExpr.prototype.param = function(...args) {
+  const paramdef = ['name', [types.XsString], true, false];
+  const checkedArgs = bldrbase.makeSingleArgs('cts.param', 1, paramdef, args);
+  return new types.CtsParam('cts', 'param', checkedArgs);
+};
+
 class Builder extends bldrgen.PlanBuilder {
   constructor() {
     super({});

--- a/lib/server-types-generated.js
+++ b/lib/server-types-generated.js
@@ -89,6 +89,13 @@ class CtsQuery extends Item {
   }
 
 }
+class CtsParam extends ServerType {
+
+  constructor(ns, fn, args) {
+    super(ns, fn, args);
+  }
+
+}
 class CtsRegion extends Item {
 
   constructor(ns, fn, args) {
@@ -724,6 +731,7 @@ CtsPathReference: CtsPathReference,
 CtsPeriod: CtsPeriod,
 CtsPoint: CtsPoint,
 CtsPolygon: CtsPolygon,
+CtsParam: CtsParam,
 CtsQuery: CtsQuery,
 CtsReference: CtsReference,
 CtsRegion: CtsRegion,

--- a/lib/server-types-generated.js
+++ b/lib/server-types-generated.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 'use strict';
 

--- a/test-basic/optic-cts-param-test.js
+++ b/test-basic/optic-cts-param-test.js
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+
+/**
+ * Integration test for cts.param support in Optic plan builder (MLE-27883).
+ * 
+ * This test requires a running MarkLogic server with:
+ * - A "manager" collection with sample documents
+ * - Connection configured via testconfig or environment
+ * 
+ * Run with: npx mocha test-basic/optic-cts-param-test.js
+ */
+
+const should = require('should');
+const valcheck = require('core-util-is');
+
+const testconfig = require('../etc/test-config.js');
+const marklogic = require('../');
+
+// Allow overriding connection info via environment or direct config
+const connInfo = {
+  host: process.env.ML_TEST_HOST || testconfig.testHost || 'localhost',
+  port: process.env.ML_TEST_PORT || 8000,
+  database: process.env.ML_TEST_DATABASE || 'Documents',
+  authType: process.env.ML_TEST_AUTH_TYPE || 'digest',
+  user: process.env.ML_TEST_USER || testconfig.restWriterConnection.user,
+  password: process.env.ML_TEST_PASSWORD || testconfig.restWriterConnection.password,
+};
+
+const db = marklogic.createDatabaseClient(connInfo);
+const op = marklogic.planBuilder;
+
+describe('cts.param integration tests (MLE-27883)', function() {
+  this.timeout(10000); // Allow 10 seconds for server queries
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Test: collectionQuery with cts.param binding
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  describe('op.cts.collectionQuery with cts.param', function() {
+
+    it('should build a plan that compiles', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'master')
+        .where(op.cts.collectionQuery(op.cts.param('collection')))
+        .select(['id', 'name']);
+      
+      should.exist(plan, 'plan should exist');
+      should.exist(plan.export, 'plan should have export method');
+      
+      const exported = plan.export();
+      should.exist(exported, 'exported plan should exist');
+      valcheck.isObject(exported).should.equal(true);
+      Object.keys(exported).length.should.be.greaterThan(0);
+    });
+
+    it('should serialize cts.param with ns:"cts" in the plan', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'master')
+        .where(op.cts.collectionQuery(op.cts.param('collection')))
+        .select(['id', 'name']);
+      
+      const exported = plan.export();
+      const serialized = JSON.stringify(exported);
+      
+      // Verify cts.param is present with correct namespace
+      should(serialized).containEql('"param"');
+      should(serialized).containEql('"cts"');
+      should(serialized).not.containEql('collection-query.*"ns":"op"');
+    });
+
+    it('should execute query with collection parameter binding', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'master')
+        .where(op.cts.collectionQuery(op.cts.param('collection')))
+        .select(['id', 'name', 'date']);
+      
+      return db.rows.query(plan, {
+        bindings: {
+          collection: { value: '/optic/test', type: 'string' }
+        }
+      })
+      .then(function(response) {
+        should.exist(response, 'response should exist');
+        valcheck.isObject(response).should.equal(true);
+        response.should.have.property('columns');
+        response.should.have.property('rows');
+        
+        // Verify structure
+        const columns = response.columns;
+        should.exist(columns, 'response should have columns');
+        valcheck.isArray(columns).should.equal(true);
+        columns.length.should.be.above(0);
+        
+        // Verify data was returned
+        const rows = response.rows;
+        should.exist(rows, 'response should have rows');
+        rows.length.should.be.above(0);
+      });
+    });
+
+    it('should support multiple cts.param bindings in a single plan', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'musician')
+        .where(
+          op.cts.andQuery([
+            op.cts.collectionQuery(op.cts.param('collection')),
+            op.cts.jsonPropertyWordQuery(op.cts.param('propertyName'), op.cts.param('keyword'))
+          ])
+        )
+        .select(['lastName', 'firstName']);
+      
+      const exported = plan.export();
+      const serialized = JSON.stringify(exported);
+      
+      // Should contain at least 2 cts.param references
+      const paramMatches = serialized.match(/"fn":"param"/g);
+      should.exist(paramMatches, 'should have param function references');
+      paramMatches.length.should.be.greaterThanOrEqual(2);
+    });
+
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Test: Other cts.param combinations
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  describe('other cts functions with cts.param', function() {
+
+    it('should support jsonPropertyWordQuery with cts.param text binding', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'musician')
+        .where(op.cts.jsonPropertyWordQuery('instrument', op.cts.param('searchTerm')))
+        .select(['lastName', 'firstName']);
+      
+      const exported = plan.export();
+      should.exist(exported);
+      
+      const serialized = JSON.stringify(exported);
+      should(serialized).containEql('"json-property-word-query"');
+      should(serialized).containEql('"param"');
+    });
+
+    it('should support jsonPropertyValueQuery with cts.param bindings', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'musician')
+        .where(
+          op.cts.jsonPropertyValueQuery(
+            op.cts.param('propertyName'),
+            op.cts.param('propertyValue')
+          )
+        )
+        .select(['lastName', 'firstName']);
+      
+      const exported = plan.export();
+      should.exist(exported);
+      
+      const serialized = JSON.stringify(exported);
+      should(serialized).containEql('"json-property-value-query"');
+      should(serialized).containEql('"param"');
+    });
+
+    it('should support collectionQuery with cts.param on master view', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'master')
+        .where(op.cts.collectionQuery(op.cts.param('col')))
+        .select(['id', 'name', 'date'])
+        .orderBy('id');
+      
+      const exported = plan.export();
+      should.exist(exported);
+      
+      const serialized = JSON.stringify(exported);
+      should(serialized).containEql('"collection-query"');
+      should(serialized).containEql('"param"');
+    });
+
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Test: Negative cases — op.param() must NOT be accepted by cts query functions
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  describe('negative: op.param() rejected by cts query functions', function() {
+
+    it('should throw when passing op.param() to collectionQuery', function() {
+      should.throws(() => {
+        op.cts.collectionQuery(op.param('myParam'));
+      }, /cts\.collectionQuery/);
+    });
+
+    it('should throw when passing op.param() to wordQuery', function() {
+      should.throws(() => {
+        op.cts.wordQuery(op.param('myParam'));
+      }, /cts\.wordQuery/);
+    });
+
+    it('should throw when passing op.param() as text to jsonPropertyWordQuery', function() {
+      should.throws(() => {
+        op.cts.jsonPropertyWordQuery('instrument', op.param('myParam'));
+      }, /cts\.jsonPropertyWordQuery/);
+    });
+
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────────
+  // Test: Parameter distinctness (cts.param vs op.param)
+  // ──────────────────────────────────────────────────────────────────────────────
+
+  describe('cts.param namespace distinctness', function() {
+
+    it('should use ns:"cts" not ns:"op" for cts.param', function() {
+      const plan = op
+        .fromView('opticUnitTest', 'master')
+        .where(op.cts.collectionQuery(op.cts.param('collection')))
+        .select(['id', 'name']);
+      
+      const exported = plan.export();
+      const serialized = JSON.stringify(exported);
+      
+      // Find the param node and verify namespace
+      const lines = serialized.split('\n');
+      let foundCtsParam = false;
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes('"fn":"param"')) {
+          // Check preceding and following lines for ns
+          const contextStart = Math.max(0, i - 5);
+          const contextEnd = Math.min(lines.length, i + 5);
+          const context = lines.slice(contextStart, contextEnd).join('\n');
+          
+          if (context.includes('"ns":"cts"')) {
+            foundCtsParam = true;
+            // Ensure it's not op.param
+            should(context).not.containEql('"ns":"op".*"fn":"param"');
+            break;
+          }
+        }
+      }
+      
+      should(foundCtsParam).equal(true, 'should find cts.param with ns:"cts"');
+    });
+
+  });
+
+});

--- a/test-basic/optic-cts-param-test.js
+++ b/test-basic/optic-cts-param-test.js
@@ -6,7 +6,8 @@
  * Integration test for cts.param support in Optic plan builder (MLE-27883).
  * 
  * This test requires a running MarkLogic server with:
- * - A "manager" collection with sample documents
+ * - Documents in the /optic/test collection
+ * - TDE views under the opticUnitTest schema, including master and musician
  * - Connection configured via testconfig or environment
  * 
  * Run with: npx mocha test-basic/optic-cts-param-test.js

--- a/test-basic/optic-cts-param-test.js
+++ b/test-basic/optic-cts-param-test.js
@@ -68,7 +68,11 @@ describe('cts.param integration tests (MLE-27883)', function() {
       // Verify cts.param is present with correct namespace
       should(serialized).containEql('"param"');
       should(serialized).containEql('"cts"');
-      should(serialized).not.containEql('collection-query.*"ns":"op"');
+      // Traverse the exported plan to verify collection-query uses ns:"cts"
+      const whereClause = exported.$optic.args.find(a => a.fn === 'where');
+      should.exist(whereClause, 'plan should have a where clause');
+      should(whereClause.args[0].ns).equal('cts', 'collection-query should use ns:"cts"');
+      should(whereClause.args[0].fn).equal('collection-query');
     });
 
     it('should execute query with collection parameter binding', function() {
@@ -218,28 +222,21 @@ describe('cts.param integration tests (MLE-27883)', function() {
         .select(['id', 'name']);
       
       const exported = plan.export();
-      const serialized = JSON.stringify(exported);
       
-      // Find the param node and verify namespace
-      const lines = serialized.split('\n');
-      let foundCtsParam = false;
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes('"fn":"param"')) {
-          // Check preceding and following lines for ns
-          const contextStart = Math.max(0, i - 5);
-          const contextEnd = Math.min(lines.length, i + 5);
-          const context = lines.slice(contextStart, contextEnd).join('\n');
-          
-          if (context.includes('"ns":"cts"')) {
-            foundCtsParam = true;
-            // Ensure it's not op.param
-            should(context).not.containEql('"ns":"op".*"fn":"param"');
-            break;
-          }
+      // Traverse the exported plan to find the param node and verify its namespace
+      function findNode(obj, fnName) {
+        if (!obj || typeof obj !== 'object') { return null; }
+        if (obj.fn === fnName) { return obj; }
+        for (const val of Object.values(obj)) {
+          const found = findNode(val, fnName);
+          if (found) { return found; }
         }
+        return null;
       }
       
-      should(foundCtsParam).equal(true, 'should find cts.param with ns:"cts"');
+      const paramNode = findNode(exported, 'param');
+      should.exist(paramNode, 'should find a param node in the exported plan');
+      should(paramNode.ns).equal('cts', 'param node should use ns:"cts" not ns:"op"');
     });
 
   });

--- a/test-typescript/optic-cts-param-runtime.test.ts
+++ b/test-typescript/optic-cts-param-runtime.test.ts
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+
+/// <reference path="../marklogic.d.ts" />
+
+/**
+ * Runtime smoke tests for cts.param support in Optic plan builder (MLE-27883).
+ *
+ * These tests verify that:
+ * - op.cts.param() constructs correctly with ns:"cts" (not ns:"op")
+ * - cts.param() can be passed to all value-accepting CTS query functions
+ * - Plan export serializes cts.param with the correct JSON shape
+ *
+ * No MarkLogic server connection required — tests only verify plan construction
+ * and serialization (plan.export()).
+ *
+ * Run with: npm run test:compile && npx mocha test-typescript/*.js
+ */
+
+import should = require('should');
+const marklogic = require('../lib/marklogic.js');
+
+const op = marklogic.planBuilder;
+
+// Helper: extract the cts.param node from a serialized plan arg
+function findCtsParam(obj: any): any {
+  if (obj && typeof obj === 'object') {
+    if (obj.ns === 'cts' && obj.fn === 'param') return obj;
+    for (const key of Object.keys(obj)) {
+      const found = findCtsParam(obj[key]);
+      if (found) return found;
+    }
+  }
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      const found = findCtsParam(item);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+describe('cts.param Optic plan builder smoke tests (MLE-27883)', function() {
+
+  // ── cts.param construction ──────────────────────────────────────────────────
+
+  describe('op.cts.param()', function() {
+
+    it('returns an object (not null/undefined)', function() {
+      const p = op.cts.param('myParam');
+      should(p).not.be.null();
+      should(p).not.be.undefined();
+    });
+
+    it('serializes with ns:"cts"', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.collectionQuery(op.cts.param('col')));
+      const exported = plan.export();
+      const paramNode = findCtsParam(exported);
+      should.exist(paramNode, 'expected a cts.param node in the exported plan');
+      paramNode.ns.should.equal('cts');
+    });
+
+    it('serializes with fn:"param"', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.collectionQuery(op.cts.param('col')));
+      const exported = plan.export();
+      const paramNode = findCtsParam(exported);
+      paramNode.fn.should.equal('param');
+    });
+
+    it('serializes the name as the sole arg', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.collectionQuery(op.cts.param('myCollection')));
+      const exported = plan.export();
+      const paramNode = findCtsParam(exported);
+      paramNode.args.should.be.an.Array().and.have.length(1);
+      paramNode.args[0].should.equal('myCollection');
+    });
+
+    it('is distinct from op.param (ns must be "cts" not "op")', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.collectionQuery(op.cts.param('col')));
+      const exported = plan.export();
+      const paramNode = findCtsParam(exported);
+      paramNode.ns.should.not.equal('op');
+    });
+
+  });
+
+  // ── Negative: op.param() must be rejected by cts query functions ─────────────
+
+  describe('negative: op.param() rejected by cts query functions', function() {
+
+    it('should throw when passing op.param() to collectionQuery', function() {
+      should.throws(() => {
+        op.cts.collectionQuery(op.param('myParam'));
+      }, /cts\.collectionQuery/);
+    });
+
+    it('should throw when passing op.param() to wordQuery', function() {
+      should.throws(() => {
+        op.cts.wordQuery(op.param('myParam'));
+      }, /cts\.wordQuery/);
+    });
+
+    it('should throw when passing op.param() as text to jsonPropertyWordQuery', function() {
+      should.throws(() => {
+        op.cts.jsonPropertyWordQuery('instrument', op.param('myParam'));
+      }, /cts\.jsonPropertyWordQuery/);
+    });
+
+  });
+
+  // ── collectionQuery ─────────────────────────────────────────────────────────
+
+  describe('cts.collectionQuery with cts.param', function() {
+
+    it('accepts cts.param as uris argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(op.cts.collectionQuery(op.cts.param('col')));
+      });
+    });
+
+    it('serializes collectionQuery with nested cts.param', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.collectionQuery(op.cts.param('col')));
+      const exported = plan.export();
+      const str = JSON.stringify(exported);
+      should(str).containEql('"collection-query"');
+      should(str).containEql('"param"');
+    });
+
+  });
+
+  // ── directoryQuery ──────────────────────────────────────────────────────────
+
+  describe('cts.directoryQuery with cts.param', function() {
+
+    it('accepts cts.param as uris argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(op.cts.directoryQuery(op.cts.param('dir')));
+      });
+    });
+
+  });
+
+  // ── documentQuery ───────────────────────────────────────────────────────────
+
+  describe('cts.documentQuery with cts.param', function() {
+
+    it('accepts cts.param as uris argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(op.cts.documentQuery(op.cts.param('uri')));
+      });
+    });
+
+  });
+
+  // ── wordQuery ───────────────────────────────────────────────────────────────
+
+  describe('cts.wordQuery with cts.param', function() {
+
+    it('accepts cts.param as text argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(op.cts.wordQuery(op.cts.param('word')));
+      });
+    });
+
+    it('serializes wordQuery with nested cts.param', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.wordQuery(op.cts.param('word')));
+      const exported = plan.export();
+      const str = JSON.stringify(exported);
+      should(str).containEql('"word-query"');
+      should(str).containEql('"param"');
+    });
+
+  });
+
+  // ── elementWordQuery ────────────────────────────────────────────────────────
+
+  describe('cts.elementWordQuery with cts.param', function() {
+
+    it('accepts cts.param as text argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementWordQuery(op.xs.QName('title'), op.cts.param('word'))
+        );
+      });
+    });
+
+  });
+
+  // ── elementAttributeWordQuery ───────────────────────────────────────────────
+
+  describe('cts.elementAttributeWordQuery with cts.param', function() {
+
+    it('accepts cts.param as text argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementAttributeWordQuery(
+            op.xs.QName('elem'), op.xs.QName('attr'), op.cts.param('word')
+          )
+        );
+      });
+    });
+
+  });
+
+  // ── elementValueQuery ───────────────────────────────────────────────────────
+
+  describe('cts.elementValueQuery with cts.param', function() {
+
+    it('accepts cts.param as text argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementValueQuery(op.xs.QName('title'), op.cts.param('val'))
+        );
+      });
+    });
+
+  });
+
+  // ── elementRangeQuery ───────────────────────────────────────────────────────
+
+  describe('cts.elementRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as value argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementRangeQuery(op.xs.QName('age'), '=', op.cts.param('ageVal'))
+        );
+      });
+    });
+
+  });
+
+  // ── elementAttributeRangeQuery ──────────────────────────────────────────────
+
+  describe('cts.elementAttributeRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as value argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementAttributeRangeQuery(
+            op.xs.QName('elem'), op.xs.QName('attr'), '=', op.cts.param('val')
+          )
+        );
+      });
+    });
+
+  });
+
+  // ── elementAttributeValueQuery ──────────────────────────────────────────────
+
+  describe('cts.elementAttributeValueQuery with cts.param', function() {
+
+    it('accepts cts.param as text argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.elementAttributeValueQuery(
+            op.xs.QName('elem'), op.xs.QName('attr'), op.cts.param('text')
+          )
+        );
+      });
+    });
+
+  });
+
+  // ── fieldRangeQuery ─────────────────────────────────────────────────────────
+
+  describe('cts.fieldRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as value argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.fieldRangeQuery(op.cts.param('fieldName'), '=', op.cts.param('val'))
+        );
+      });
+    });
+
+  });
+
+  // ── fieldValueQuery ─────────────────────────────────────────────────────────
+
+  describe('cts.fieldValueQuery with cts.param', function() {
+
+    it('accepts cts.param as field-name and text arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.fieldValueQuery(op.cts.param('fieldName'), op.cts.param('text'))
+        );
+      });
+    });
+
+  });
+
+  // ── fieldWordQuery ──────────────────────────────────────────────────────────
+
+  describe('cts.fieldWordQuery with cts.param', function() {
+
+    it('accepts cts.param as field-name and text arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.fieldWordQuery(op.cts.param('fieldName'), op.cts.param('word'))
+        );
+      });
+    });
+
+  });
+
+  // ── jsonPropertyRangeQuery ──────────────────────────────────────────────────
+
+  describe('cts.jsonPropertyRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as property-name and value arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.jsonPropertyRangeQuery(op.cts.param('prop'), '=', op.cts.param('val'))
+        );
+      });
+    });
+
+  });
+
+  // ── jsonPropertyValueQuery ──────────────────────────────────────────────────
+
+  describe('cts.jsonPropertyValueQuery with cts.param', function() {
+
+    it('accepts cts.param as property-name and value arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.jsonPropertyValueQuery(op.cts.param('prop'), op.cts.param('val'))
+        );
+      });
+    });
+
+    it('serializes jsonPropertyValueQuery with nested cts.param', function() {
+      const plan = op.fromView('s', 'v')
+        .where(op.cts.jsonPropertyValueQuery(op.cts.param('prop'), op.cts.param('val')));
+      const exported = plan.export();
+      const str = JSON.stringify(exported);
+      should(str).containEql('"json-property-value-query"');
+      should(str).containEql('"param"');
+      should(str).containEql('"cts"');
+    });
+
+  });
+
+  // ── jsonPropertyWordQuery ───────────────────────────────────────────────────
+
+  describe('cts.jsonPropertyWordQuery with cts.param', function() {
+
+    it('accepts cts.param as property-name and text arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.jsonPropertyWordQuery(op.cts.param('prop'), op.cts.param('word'))
+        );
+      });
+    });
+
+  });
+
+  // ── pathRangeQuery ──────────────────────────────────────────────────────────
+
+  describe('cts.pathRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as path-name and value arguments without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.pathRangeQuery(op.cts.param('path'), '=', op.cts.param('val'))
+        );
+      });
+    });
+
+  });
+
+  // ── rangeQuery ──────────────────────────────────────────────────────────────
+
+  describe('cts.rangeQuery with cts.param', function() {
+
+    it('accepts cts.param as value argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.rangeQuery(
+            op.cts.jsonPropertyReference('salary'),
+            '=',
+            op.cts.param('salaryVal')
+          )
+        );
+      });
+    });
+
+  });
+
+  // ── columnRangeQuery ────────────────────────────────────────────────────────
+
+  describe('cts.columnRangeQuery with cts.param', function() {
+
+    it('accepts cts.param as value argument without throwing', function() {
+      should.doesNotThrow(() => {
+        op.fromView('s', 'v').where(
+          op.cts.columnRangeQuery('main', 'employees', 'Position', op.cts.param('posVal'))
+        );
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
# Summary
server-types-generated.js:	Added CtsParam class extending ServerType; exported it
plan-builder.js:	Added bldrgen.CtsExpr.prototype.param function
plan-builder-generated.js:	Added types.CtsParam as accepted type at 19 CTS function parameter sites
optic-cts-param-runtime.test.ts:	New file — 30 smoke tests (no server required)
optic-cts-param-test.js:	New file — 11 integration tests (1 live server call; 10 local plan-construction/negative tests)


# Smoke tests (no server, test-typescript):
```
npm run test:compile && npx mocha test-typescript/optic-cts-param-runtime.test.js
→ 30 passing (18ms)
```

# Integration tests (test-basic, requires MarkLogic 12.1):
```
$env:ML_TEST_HOST='10.65.16.48'; ... npx mocha test-basic/optic-cts-param-test.js
→ 11 passing (164ms)
```

# Verification steps:

Smoke tests (instant, no server needed)
```
npm run test:compile
npx mocha test-typescript/optic-cts-param-runtime.test.js
```

Integration tests (requires MarkLogic 12.1)
```
$env:ML_TEST_HOST='10.65.16.48'; $env:ML_TEST_PORT='8000'; $env:ML_TEST_DATABASE='Documents'
$env:ML_TEST_AUTH_TYPE='digest'; $env:ML_TEST_USER='admin'; $env:ML_TEST_PASSWORD='admin';
npx mocha test-basic/optic-cts-param-test.js
```

