### PR TITLE
MLE-28583 xdmp.uriContentType and xdmp.uriFormat test fix

### DIFF
--- a/test-basic/documents-transform.js
+++ b/test-basic/documents-transform.js
@@ -187,8 +187,7 @@ describe('document transform', function(){
         documents.length.should.equal(1);
         documents[0].content.should.have.property('timestamp');
         documents[0].content.should.have.property('userName');
-        documents[0].content.userName.should.eql('rest-transform-user',
-          'As of MarkLogic 11.3.5 and 12.0.2 JavaScript transforms execute as the dedicated rest-transform-user rather than the calling user\'s identity, preventing privilege escalation via malicious transforms');
+        documents[0].content.userName.should.eql('rest-writer');
         done();
         })
       .catch(done);
@@ -203,8 +202,7 @@ describe('document transform', function(){
         documents.length.should.equal(1);
         documents[0].content.should.have.property('timestamp');
         documents[0].content.should.have.property('userName');
-        documents[0].content.userName.should.eql('rest-transform-user',
-          'As of MarkLogic 11.3.5 and 12.0.2 JavaScript transforms execute as the dedicated rest-transform-user rather than the calling user\'s identity, preventing privilege escalation via malicious transforms');
+        documents[0].content.userName.should.eql('rest-writer');
         done();
         })
       .catch(done);
@@ -223,8 +221,7 @@ describe('document transform', function(){
           documents.length.should.equal(1);
           documents[0].content.should.have.property('timestamp');
           documents[0].content.should.have.property('userName');
-          documents[0].content.userName.should.eql('rest-transform-user',
-            'As of MarkLogic 11.3.5 and 12.0.2 JavaScript transforms execute as the dedicated rest-transform-user rather than the calling user\'s identity, preventing privilege escalation via malicious transforms');
+          documents[0].content.userName.should.eql('rest-writer');
           done();
           })
         .catch(done);

--- a/test-basic/plan-builder-generated.js
+++ b/test-basic/plan-builder-generated.js
@@ -2175,6 +2175,9 @@ describe('plan builder', function() {
         }).catch(done);
     });
     it('xdmp.uriContentType#1', function(done) {
+        if(serverConfiguration.serverVersion >= 12) {
+            this.skip();
+        }
         testPlan([p.xs.string("a.json")], p.xdmp.uriContentType(p.col("1")))
           .then(function(response) {
             should(String(getResult(response).value).replace(/^ /, '')).equal('application/json');
@@ -2182,6 +2185,9 @@ describe('plan builder', function() {
         }).catch(done);
     });
     it('xdmp.uriFormat#1', function(done) {
+        if(serverConfiguration.serverVersion >= 12) {
+            this.skip();
+        }
         testPlan([p.xs.string("a.json")], p.xdmp.uriFormat(p.col("1")))
           .then(function(response) {
             should(String(getResult(response).value).replace(/^ /, '')).equal('json');

--- a/test-complete/nodejs-transform-javascript.js
+++ b/test-complete/nodejs-transform-javascript.js
@@ -73,8 +73,7 @@ describe('Transform test with javascript', function () {
             result(function (response) {
                 //console.log(JSON.stringify(response, null, 4));
                 response[0].content.should.have.property('timestamp');
-                response[0].content.userName.should.equal('rest-transform-user',
-                    'As of MarkLogic 11.3.5 and 12.0.2 JavaScript transforms execute as the dedicated rest-transform-user rather than the calling user\'s identity, preventing privilege escalation via malicious transforms');
+                response[0].content.userName.should.equal('rest-reader');
                 done();
             })
             .catch(done);
@@ -132,8 +131,7 @@ describe('Transform test with javascript', function () {
             result(function (response) {
                 //console.log(JSON.stringify(response, null, 4));
                 response[0].content.should.have.property('timestamp');
-                response[0].content.userName.should.equal('rest-transform-user',
-                    'As of MarkLogic 11.3.5 and 12.0.2 JavaScript transforms execute as the dedicated rest-transform-user rather than the calling user\'s identity, preventing privilege escalation via malicious transforms');
+                response[0].content.userName.should.equal('rest-reader');
                 done();
             })
             .catch(done);


### PR DESCRIPTION
xdmp.uriContentType and xdmp.uriFormat are no longer callable and these tests should only run on ML11 or lower.