### PR TITLE
MLE-29694 fixes for vulnerabilities and flaky tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "form-data": "4.0.4",
         "json-text-sequence": "4.0.2",
         "multipart-stream": "2.0.1",
-        "qs": "6.15.0",
+        "qs": "6.15.2",
         "through2": "4.0.2"
       },
       "devDependencies": {
@@ -4213,9 +4213,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "form-data": "4.0.4",
     "json-text-sequence": "4.0.2",
     "multipart-stream": "2.0.1",
-    "qs": "6.15.0",
+    "qs": "6.15.2",
     "through2": "4.0.2"
   },
   "repository": {

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -56,7 +56,7 @@ tasks.register("curlPeople", Exec) {
     '-X', 'POST',
     '--data-binary', '@./src/main/turtle/people/people.ttl',
     '-H', 'Content-type: text/turtle',
-    'http://localhost:8079/v1/graphs?graph=/people'
+    "http://${mlHost}:8079/v1/graphs?graph=/people"
   ]
 }
 
@@ -69,7 +69,7 @@ tasks.register("curlCompanies", Exec) {
     '-X', 'POST',
     '--data-binary', '@./src/main/turtle/companies/companies_100.ttl',
     '-H', 'Content-type: text/turtle',
-    'http://localhost:8079/v1/graphs?graph=/optic/sparql/test/companies.ttl'
+    "http://${mlHost}:8079/v1/graphs?graph=/optic/sparql/test/companies.ttl"
   ]
 }
 

--- a/test-basic/plan-search.js
+++ b/test-basic/plan-search.js
@@ -320,7 +320,7 @@ describe('search', function() {
         xdmp:document-insert("range-prop-2.json", $jsondoc2, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-insert("range-prop-3.json", $jsondoc3, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-set-properties("range-prop-1.json", (<my-prop>opticfragmentpropvalue</my-prop>)),
-        (: 600s required for CI pipelines where after-hook may run well after setup :)
+        (: 300s required for CI pipelines where after-hook may run well after setup :)
         xdmp:lock-acquire("range-prop-1.json", "exclusive", "0", "dog rose",  xs:unsignedLong(300)),
         xdmp:lock-acquire("range-prop-2.json", "exclusive", "0", "cat tulip", xs:unsignedLong(300)),
         xdmp:lock-acquire("range-prop-3.json", "exclusive", "0", "duck lily", xs:unsignedLong(300))

--- a/test-basic/plan-search.js
+++ b/test-basic/plan-search.js
@@ -320,27 +320,28 @@ describe('search', function() {
         xdmp:document-insert("range-prop-2.json", $jsondoc2, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-insert("range-prop-3.json", $jsondoc3, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-set-properties("range-prop-1.json", (<my-prop>opticfragmentpropvalue</my-prop>)),
-        xdmp:lock-acquire("range-prop-1.json", "exclusive", "0", "dog rose",  xs:unsignedLong(600)),
-        xdmp:lock-acquire("range-prop-2.json", "exclusive", "0", "cat tulip", xs:unsignedLong(600)),
-        xdmp:lock-acquire("range-prop-3.json", "exclusive", "0", "duck lily", xs:unsignedLong(600))
+        (: 600s required for CI pipelines where after-hook may run well after setup :)
+        xdmp:lock-acquire("range-prop-1.json", "exclusive", "0", "dog rose",  xs:unsignedLong(300)),
+        xdmp:lock-acquire("range-prop-2.json", "exclusive", "0", "cat tulip", xs:unsignedLong(300)),
+        xdmp:lock-acquire("range-prop-3.json", "exclusive", "0", "duck lily", xs:unsignedLong(300))
       )
     `;
 
     const teardownReleaseLocks = `
       xquery version "1.0-ml";
       (
-        try { xdmp:lock-release("range-prop-1.json") } catch ($e) { () },
-        try { xdmp:lock-release("range-prop-2.json") } catch ($e) { () },
-        try { xdmp:lock-release("range-prop-3.json") } catch ($e) { () }
+        try { xdmp:lock-release("range-prop-1.json") } catch ($e) { if ($e/error:code = "XDMP-NOTLOCKED") then () else xdmp:rethrow() },
+        try { xdmp:lock-release("range-prop-2.json") } catch ($e) { if ($e/error:code = "XDMP-NOTLOCKED") then () else xdmp:rethrow() },
+        try { xdmp:lock-release("range-prop-3.json") } catch ($e) { if ($e/error:code = "XDMP-NOTLOCKED") then () else xdmp:rethrow() }
       )
     `;
 
     const teardownDeleteDocs = `
       xquery version "1.0-ml";
       (
-        xdmp:document-delete("range-prop-1.json"),
-        xdmp:document-delete("range-prop-2.json"),
-        xdmp:document-delete("range-prop-3.json")
+        try { xdmp:document-delete("range-prop-1.json") } catch ($e) { if ($e/error:code = "XDMP-DOCNOTFOUND") then () else xdmp:rethrow() },
+        try { xdmp:document-delete("range-prop-2.json") } catch ($e) { if ($e/error:code = "XDMP-DOCNOTFOUND") then () else xdmp:rethrow() },
+        try { xdmp:document-delete("range-prop-3.json") } catch ($e) { if ($e/error:code = "XDMP-DOCNOTFOUND") then () else xdmp:rethrow() }
       )
     `;
 

--- a/test-basic/plan-search.js
+++ b/test-basic/plan-search.js
@@ -320,18 +320,18 @@ describe('search', function() {
         xdmp:document-insert("range-prop-2.json", $jsondoc2, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-insert("range-prop-3.json", $jsondoc3, xdmp:default-permissions(), ("elemCol","jsondoc-range")),
         xdmp:document-set-properties("range-prop-1.json", (<my-prop>opticfragmentpropvalue</my-prop>)),
-        xdmp:lock-acquire("range-prop-1.json", "exclusive", "0", "dog rose",  xs:unsignedLong(120)),
-        xdmp:lock-acquire("range-prop-2.json", "exclusive", "0", "cat tulip", xs:unsignedLong(120)),
-        xdmp:lock-acquire("range-prop-3.json", "exclusive", "0", "duck lily", xs:unsignedLong(120))
+        xdmp:lock-acquire("range-prop-1.json", "exclusive", "0", "dog rose",  xs:unsignedLong(600)),
+        xdmp:lock-acquire("range-prop-2.json", "exclusive", "0", "cat tulip", xs:unsignedLong(600)),
+        xdmp:lock-acquire("range-prop-3.json", "exclusive", "0", "duck lily", xs:unsignedLong(600))
       )
     `;
 
     const teardownReleaseLocks = `
       xquery version "1.0-ml";
       (
-        xdmp:lock-release("range-prop-1.json"),
-        xdmp:lock-release("range-prop-2.json"),
-        xdmp:lock-release("range-prop-3.json")
+        try { xdmp:lock-release("range-prop-1.json") } catch ($e) { () },
+        try { xdmp:lock-release("range-prop-2.json") } catch ($e) { () },
+        try { xdmp:lock-release("range-prop-3.json") } catch ($e) { () }
       )
     `;
 


### PR DESCRIPTION
Bumped qs from 6.15.0 to 6.15.2 

Increased xdmp lock timeouts in plan-search fragment options tests and made teardown more tolerant
