### PR TITLE
MLE-30686 MLE-30964 form-data and markdown-it dependency bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,15 +3293,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/markdown-it/-/14.1.1/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/markdown-it/-/14.2.0/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "big-integer": "1.6.52",
         "concat-stream": "2.0.0",
         "duplexify": "4.1.3",
-        "form-data": "4.0.4",
+        "form-data": "4.0.6",
         "json-text-sequence": "4.0.2",
         "multipart-stream": "2.0.1",
         "qs": "6.15.2",
@@ -2001,16 +2001,16 @@
       "license": "BSD"
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/form-data/-/4.0.4/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/form-data/-/4.0.6/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "big-integer": "1.6.52",
     "concat-stream": "2.0.0",
     "duplexify": "4.1.3",
-    "form-data": "4.0.4",
+    "form-data": "4.0.6",
     "json-text-sequence": "4.0.2",
     "multipart-stream": "2.0.1",
     "qs": "6.15.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "diff": "9.0.0",
     "glob": "12.0.0",
     "glob-parent": "6.0.2",
-    "markdown-it": "14.1.1",
+    "markdown-it": "14.2.0",
     "minimatch": "10.2.4",
     "semver": "7.5.3",
     "serialize-javascript": "7.0.5",


### PR DESCRIPTION
Bumped form-data up from 4.0.4 to 4.0.6 and markdown-it override from 14.1.1 to 14.2.0.

https://progresssoftware.atlassian.net/browse/MLE-30686
https://progresssoftware.atlassian.net/browse/MLE-30964