### PR TITLE
MLE-30154 Pin Mocha to 11.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "gulp-mocha": "^10.0.1",
         "intercept-stdout": "0.1.2",
         "jsdoc": "4.0.5",
-        "mocha": "^11.7.5",
+        "mocha": "11.7.5",
         "mocha-junit-reporter": "2.2.1",
         "moment": "2.30.1",
         "sanitize-html": "^2.17.4",
@@ -3497,9 +3497,9 @@
       "optional": true
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/mocha/-/11.7.6/mocha-11.7.6.tgz",
-      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "version": "11.7.5",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/mocha/-/11.7.5/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gulp-mocha": "^10.0.1",
     "intercept-stdout": "0.1.2",
     "jsdoc": "4.0.5",
-    "mocha": "^11.7.5",
+    "mocha": "11.7.5",
     "mocha-junit-reporter": "2.2.1",
     "moment": "2.30.1",
     "sanitize-html": "^2.17.4",


### PR DESCRIPTION
## Pin Mocha to 11.7.5 to resolve `ERR_MOCHA_MULTIPLE_DONE` crash in transformAll tests

### Problem

The test-complete suite was producing 16 test failures in Jenkins for two test files:

- nodejs-dmsdk-xmlFiles-transformAll.js (15 failures)
- nodejs-dmsdk-txtFiles-transformAll.js (1 failure)

Every affected test showed `done() called multiple times` with this pattern:

```
Error: done() called multiple times in test <...>; in addition, done() received error:
Error: Timeout of 20000ms exceeded.
{ code: 'ERR_MOCHA_TIMEOUT', timeout: 20000 }
{ code: 'ERR_MOCHA_MULTIPLE_DONE' }
Exit code: 7
```

All individual test assertions were actually **passing** (Mocha reported `N passing`), but the Mocha runner crashed post-suite with exit code 7, causing Jenkins to report the entire file as failed.

The crash originated in the `afterEach` hook, which calls `documents.remove(uris)` to clean up 100 documents after each test. On slower environments (Jenkins), this operation occasionally exceeds the hook's 20-second timeout. When the timeout fires, Mocha calls `done()` with the timeout error; when `remove()` eventually completes, it calls `done()` a second time, triggering `ERR_MOCHA_MULTIPLE_DONE` and crashing the process.

### Fix

Pinning Mocha to **11.7.5** resolves the crash. This version handles the `ERR_MOCHA_MULTIPLE_DONE` edge case without terminating the process, allowing the suite to exit cleanly (exit code 0). No changes to test source files were required.

### Verification

All three previously failing test files were re-run locally against `marklogic-server-ubi:11.3.20260630-ubi-2.2.5` after the upgrade:

| Test File | Tests | Result |
|---|---|---|
| nodejs-dmsdk-xmlFiles-transformAll.js | 17 | ✅ 17 passing, exit 0 |
| nodejs-dmsdk-txtFiles-transformAll.js | 15 | ✅ 15 passing, exit 0 |
| nodejs-temporal-advance-lsqt.js | 12 | ✅ 12 passing, exit 0 |

Note: This issue started as a result of this PR: https://github.com/marklogic/node-client-api/pull/1085