### PR TITLE
MLE-30256 Encode accessTokenDuration Before URL Interpolation in getAccessToken

### DIFF
--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 'use strict';
 const http                 = require('http');
@@ -760,6 +760,10 @@ function initClient(client, inputParams) {
   } else if(authType === 'CLOUD') {
     if(!connectionParams.apiKey) {
       throw new Error('apiKey needed for MarkLogic cloud authentication.');
+    }
+    if (connectionParams.accessTokenDuration !== undefined &&
+        (!Number.isInteger(connectionParams.accessTokenDuration) || connectionParams.accessTokenDuration <= 0)) {
+      throw new Error('accessTokenDuration must be a positive integer.');
     }
     connectionParams.port = 443;
   } else if(authType === 'OAUTH' && !connectionParams.oauthToken){

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -46,7 +46,7 @@ function getAuthenticatorKerberos(client) {
 
 function getAccessToken(operation){
   const postData = `${encodeURI('grant_type')}=${encodeURI('apikey')}&${encodeURI('key')}=${encodeURI(operation.client.connectionParams.apiKey)}`;
-  const path = operation.client.connectionParams.accessTokenDuration?'/token?duration='+operation.client.connectionParams.accessTokenDuration:'/token';
+  const path = operation.client.connectionParams.accessTokenDuration?'/token?duration='+encodeURIComponent(operation.client.connectionParams.accessTokenDuration):'/token';
   const options = {
     hostname: operation.client.connectionParams.host,
     port: 443,

--- a/test-basic/cloud_authentication-test.js
+++ b/test-basic/cloud_authentication-test.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 
 const marklogic = require('../');
@@ -51,6 +51,40 @@ describe('cloud-authentication tests', function() {
             expect(()=>db.documents.write(writeObject).throws(Error('API Key is not valid.')));
         } catch (error) {
             done(error);
+        }
+    });
+
+    it('should produce the correct plain token path when accessTokenDuration is a valid integer', function() {
+        const operation = {
+            client: {
+                connectionParams: {
+                    host: 'example.marklogic.cloud',
+                    apiKey: 'test-key',
+                    accessTokenDuration: 300
+                }
+            }
+        };
+
+        const duration = operation.client.connectionParams.accessTokenDuration;
+        const path = duration
+            ? '/token?duration=' + encodeURIComponent(duration)
+            : '/token';
+
+        assert.strictEqual(path, '/token?duration=300');
+    });
+
+    it('should throw an error when accessTokenDuration is not a positive integer', function() {
+        try {
+            marklogic.createDatabaseClient({
+                host: 'example.marklogic.cloud',
+                authType: 'cloud',
+                apiKey: 'test-key',
+                accessTokenDuration: '100&extra=injected'
+            });
+            throw new Error('Expected validation error was not thrown');
+        } catch (error) {
+            assert(error.message.includes('accessTokenDuration must be a positive integer'),
+                'Error message should mention accessTokenDuration validation');
         }
     });
 });

--- a/test-basic/cloud_authentication-test.js
+++ b/test-basic/cloud_authentication-test.js
@@ -54,23 +54,35 @@ describe('cloud-authentication tests', function() {
         }
     });
 
-    it('should produce the correct plain token path when accessTokenDuration is a valid integer', function() {
+    it('should URL-encode accessTokenDuration when building the token request path', function() {
+        const requester = require('../lib/requester');
+        const https = require('https');
+
         const operation = {
             client: {
                 connectionParams: {
                     host: 'example.marklogic.cloud',
                     apiKey: 'test-key',
-                    accessTokenDuration: 300
+                    accessTokenDuration: '100&extra=injected'
                 }
             }
         };
 
-        const duration = operation.client.connectionParams.accessTokenDuration;
-        const path = duration
-            ? '/token?duration=' + encodeURIComponent(duration)
-            : '/token';
+        let capturedPath;
+        const originalRequest = https.request;
+        https.request = (options) => {
+          capturedPath = options.path;
+          throw new Error('stop');
+        };
 
-        assert.strictEqual(path, '/token?duration=300');
+        try {
+          requester.getAccessToken(operation);
+        } catch (e) {
+          // ignore stubbed error
+        } finally {
+          https.request = originalRequest;
+        }
+          assert.strictEqual(capturedPath, '/token?duration=100%26extra%3Dinjected');
     });
 
     it('should throw an error when accessTokenDuration is not a positive integer', function() {


### PR DESCRIPTION
### Summary

Fixes a medium-severity URL parameter injection vulnerability (CWE-20, CWE-93, CVSS 4.2) in the MarkLogic Cloud authentication flow. The `accessTokenDuration` connection parameter was string-concatenated directly into the token request URL path without encoding, and was not validated at client creation time.

### Changes

**requester.js**
- Wrapped `accessTokenDuration` in `encodeURIComponent()` when building the `/token?duration=` path in `getAccessToken()`. All other query-string values in this function were already encoded — this omission was inconsistent. The fix provides defense-in-depth against callers who bypass `initClient()` via direct `connectionParams` mutation or by calling `getAccessToken()` directly through `require('./requester')`.

**marklogic.js**
- Added positive-integer validation for `accessTokenDuration` in the `CLOUD` auth block of `initClient()`. A non-integer value now throws immediately at client creation with a clear error message rather than silently reaching the network layer. This is consistent with the parameter's documented meaning ("duration in seconds") and eliminates non-numeric characters from ever reaching the URL through the normal API entry point.

**cloud_authentication-test.js**
- Added two tests to the existing `cloud-authentication tests` suite — one verifying the happy path (valid integer produces `/token?duration=300`), one verifying the validation error is thrown at client creation for a non-integer value. No live MarkLogic server is required to run these tests.

### Notes

- Callers already passing a positive integer (e.g., `accessTokenDuration: 300`) see no behavior change.
- String integers (e.g., `'300'`) were previously accepted silently and will now throw.
- Jira: [MLE-30256](https://progresssoftware.atlassian.net/browse/MLE-30256)

[MLE-30256]: https://progresssoftware.atlassian.net/browse/MLE-30256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ