### PR TITLE
MLE-30265 add warning for BASIC auth without SSL

### DIFF
--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 */
 'use strict';
 const http                 = require('http');
@@ -716,6 +716,7 @@ function initClient(client, inputParams) {
   if(inputParams.authType && inputParams.authType.toString().toLowerCase() === 'cloud' && !isSSL){
     isSSL = true;
   }
+
   const keys = ['host', 'port', 'database', 'user', 'password', 'authType', 'token', 'basePath','apiKey','accessTokenDuration',
   'enableGzippedResponses', 'oauthToken'];
   if(isSSL) {
@@ -738,6 +739,9 @@ function initClient(client, inputParams) {
   connectionParams.lookup = prefLookup;
 
   const authType = connectionParams.authType.toUpperCase();
+  if (authType === 'BASIC' && !isSSL) {
+    console.warn('Authentication type is BASIC and SSL is not enabled. This may expose credentials.');
+  }
   if ((authType === 'DIGEST' || authType === 'BASIC') &&
        ((connectionParams.user == null) || (connectionParams.password == null))) {
     throw new Error('cannot create client without user or password for '+


### PR DESCRIPTION
Warn users that the NodeJS  will transmit MarkLogic credentials in cleartext over the network if authentication type BASIC is used without SSL/TLS.