### PR TITLE
MLE-31390: [HIGH] BDSA-2026-21635 in js-yaml v4.2.0 (MarkLogic-DevExp-nodeapi)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2943,9 +2943,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/js-yaml/-/4.2.0/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -2957,7 +2957,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "diff": "9.0.0",
     "glob": "12.0.0",
     "glob-parent": "6.0.2",
+    "js-yaml": "4.3.0",
     "markdown-it": "14.2.0",
     "minimatch": "10.2.4",
     "semver": "7.5.3",


### PR DESCRIPTION
### Title:
MLE-31390: remediate BDSA-2026-21635 by pinning js-yaml to 4.3.0

### Description:
This PR remediates the high-severity vulnerability BDSA-2026-21635 in js-yaml (DoS via algorithmic complexity) for the develop branch of MarkLogic-DevExp-nodeapi.

### What changed:

Added an override to force js-yaml 4.3.0 in package.json.
Regenerated the lockfile so js-yaml resolves to 4.3.0 in package-lock.json.

### Why this approach:

4.3.0 is the recommended patched version for this advisory.
Current transitive dependents resolve js-yaml on the 4.x line, so pinning to 4.3.0 is the lowest-risk fix.
Avoids a major jump to 5.x in this security patch PR.

### Validation performed:

Confirmed the js-yaml entry resolves to 4.3.0 in package-lock.json
Confirmed no js-yaml 4.2.0 lockfile entry remains.
Ran lockfile audit; js-yaml vulnerability is no longer present in reported findings.