### PR TITLE
MLE-31646: [MEDIUM] BDSA-2026-24060 in PostCSS v8.5.15 (MarkLogic-DevExp-nodeapi)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3720,9 +3720,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/nanoid/-/3.3.12/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3730,7 +3730,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4104,9 +4103,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/postcss/-/8.5.15/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://pkg.harness.io/pkg/ct8onj8YTdaXtKaFsYCRLg/org-marklogic-npm/npm/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4122,9 +4121,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "supports-color": "7.2.0",
     "tar-fs": "2.1.4",
     "underscore": "1.13.8",
-    "wrap-ansi": "6.2.0"
+    "wrap-ansi": "6.2.0",
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
### Summary
This PR remediates vulnerability BDSA-2026-24060 (PostCSS path traversal / information disclosure) reported in Black Duck for project MarkLogic-DevExp-nodeapi on branch develop.

The vulnerable transitive version was PostCSS 8.5.15.
This PR enforces PostCSS 8.5.23 (patched) using npm overrides.

### What Changed
1. Added an override in package.json to force: postcss: 8.5.23
2. Regenerated package-lock.json so dependency resolution reflects the override.
3. Verified lockfile now resolves PostCSS to 8.5.23 in package-lock.json.

### Why This Approach

1. PostCSS is transitive (via sanitize-html), not a direct top-level dependency.
2. Upgrading sanitize-html alone did not guarantee a patched PostCSS resolution in this repo.
3. Override-based pinning provides deterministic remediation with minimal functional impact.

### Security Impact
Fixes Black Duck finding: Vulnerability ID: BDSA-2026-24060
Severity: Medium
CVSS: 6.5
Moves PostCSS from vulnerable 8.5.15 to patched 8.5.23.

### Validation
Confirmed override entry exists in package.json.
Confirmed resolved version is PostCSS 8.5.23 in package-lock.json:4106.

### Risk / Compatibility
Low risk: change is limited to dependency resolution for a transitive package.
Lockfile includes expected transitive metadata updates associated with the new PostCSS package.