### PR TITLE
MLE-30272: [Node Client] Document ML-Agent-ID Telemetry Header and Provide Opt-Out Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ const db = marklogic.createDatabaseClient({
   user:     'admin',
   password: 'admin',
   authType: 'DIGEST',
-  // enableGzippedResponses is optional and can be set to true in order to request MarkLogic to compress the response for better performance,
-    // the client will automatically decompress the response before it returns a value.
+  // Set to true to suppress the ML-Agent-ID header in each request to MarkLogic.
+  // See https://docs.progress.com/bundle/marklogic-server-monitor-12/page/topics/telemetry.html
+  disableTelemetryHeader: false,
+  // Optional; set to true to request compressed responses for improved performance. The client automatically decompresses returned values.
   enableGzippedResponses: true
 });
 
@@ -70,10 +72,9 @@ const db = marklogic.createDatabaseClient({
     authType: 'cloud',
     // basePath is optional.
     basePath: '/marklogic/test',
-    // accessTokenDuration (in seconds) is optional and can be used to customize the expiration of the access token.
+    // Optional (in seconds); customizes the expiration of the access token.
     accessTokenDuration: 10,
-    // enableGzippedResponses is optional and can be set to true in order to request MarkLogic to compress the response for better performance,
-    // the client will automatically decompress the response before it returns a value.
+    // Set to true to request compressed responses for improved performance. The client automatically decompresses returned values.
     enableGzippedResponses: true
 });
 

--- a/lib/marklogic.js
+++ b/lib/marklogic.js
@@ -250,6 +250,7 @@ function expandExtlibsWrapper(action, args) {
  * to use for SSL
  * @param {string} [passphrase] - the passphrase for the PKCS12 file
  * @param {string} [token] - the SAML token to use for authentication with the REST server
+ * @param {boolean} [disableTelemetryHeader=false] - when true, suppresses the ML-Agent-ID telemetry header on outbound requests
  * @returns {DatabaseClient} a client for accessing the database
  * as the user
  */
@@ -718,6 +719,7 @@ function initClient(client, inputParams) {
   }
 
   const keys = ['host', 'port', 'database', 'user', 'password', 'authType', 'token', 'basePath','apiKey','accessTokenDuration',
+  'disableTelemetryHeader',
   'enableGzippedResponses', 'oauthToken'];
   if(isSSL) {
     keys.push('ca', 'cert', 'ciphers', 'clientCertEngine', 'crl', 'dhparam', 'ecdhCurve', 'honorCipherOrder', 'key', 'passphrase',

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -128,7 +128,9 @@ function startRequest(operation) {
     options.headers = headers;
   }
   headers['X-Error-Accept'] = 'application/json';
-  headers['ML-Agent-ID'] = 'nodejs'; // Telemetry header
+  if (!options.disableTelemetryHeader) {
+    headers['ML-Agent-ID'] = 'nodejs'; // Telemetry header
+  }
 
   if(options.enableGzippedResponses) {
     headers['Accept-Encoding'] = 'gzip';

--- a/marklogic.d.ts
+++ b/marklogic.d.ts
@@ -56,6 +56,8 @@ declare module 'marklogic' {
     token?: string;
     /** Connection pooling agent */
     agent?: any;
+    /** When true, disables telemetry usage; see https://docs.progress.com/bundle/marklogic-server-monitor-12/page/topics/telemetry.html */
+    disableTelemetryHeader?: boolean;
     /** API version to use */
     apiVersion?: string;
   }

--- a/test-basic/telemetry-header-test.js
+++ b/test-basic/telemetry-header-test.js
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+*/
+
+'use strict';
+
+const assert = require('assert');
+const marklogic = require('../');
+const mlutil = require('../lib/mlutil');
+const requester = require('../lib/requester');
+
+function buildRequestOptions(connectionParams) {
+  return mlutil.newRequestOptions(connectionParams, '/v1/ping', 'HEAD');
+}
+
+describe('ML-Agent-ID telemetry header', function() {
+  it('should include ML-Agent-ID header by default', function() {
+    const client = marklogic.createDatabaseClient({
+      host: 'localhost',
+      port: 8000,
+      user: 'admin',
+      password: 'admin',
+      authType: 'digest'
+    });
+
+    const options = buildRequestOptions(client.connectionParams);
+    const operation = {
+      options: options,
+      requestType: 'invalid-request-type'
+    };
+
+    assert.throws(
+      () => requester.startRequest(operation),
+      /unknown request type invalid-request-type/
+    );
+    assert.strictEqual(options.headers['ML-Agent-ID'], 'nodejs');
+
+    client.release();
+  });
+
+  it('should omit ML-Agent-ID header when disableTelemetryHeader is true', function() {
+    const client = marklogic.createDatabaseClient({
+      host: 'localhost',
+      port: 8000,
+      user: 'admin',
+      password: 'admin',
+      authType: 'digest',
+      disableTelemetryHeader: true
+    });
+
+    const options = buildRequestOptions(client.connectionParams);
+    const operation = {
+      options: options,
+      requestType: 'invalid-request-type'
+    };
+
+    assert.throws(
+      () => requester.startRequest(operation),
+      /unknown request type invalid-request-type/
+    );
+    assert.strictEqual(client.connectionParams.disableTelemetryHeader, true);
+    assert.strictEqual(options.headers['ML-Agent-ID'], undefined);
+
+    client.release();
+  });
+});

--- a/test-typescript/basic-types.test.ts
+++ b/test-typescript/basic-types.test.ts
@@ -51,6 +51,14 @@ const minimalConfig: marklogic.DatabaseClientConfig = {
   password: 'admin'
 };
 
+// Test 5b: Telemetry header opt-out option should type-check
+const telemetryConfig: marklogic.DatabaseClientConfig = {
+  user: 'admin',
+  password: 'admin',
+  disableTelemetryHeader: true
+};
+const telemetryDb = marklogic.createDatabaseClient(telemetryConfig);
+
 // Test 6: Testing all auth types (all should be valid)
 const authTypes: Array<marklogic.DatabaseClientConfig['authType']> = [
   'basic',

--- a/test-typescript/telemetry-header-runtime.test.ts
+++ b/test-typescript/telemetry-header-runtime.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+
+/// <reference path="../marklogic.d.ts" />
+
+import assert = require('assert');
+
+const marklogic = require('..');
+const mlutil = require('../lib/mlutil');
+const requester = require('../lib/requester');
+
+type DatabaseClientConfig = import('marklogic').DatabaseClientConfig;
+
+function verifyTelemetryHeader(config: DatabaseClientConfig, expectedHeader: string | undefined): void {
+  const client = marklogic.createDatabaseClient(config);
+  const options = mlutil.newRequestOptions(client.connectionParams, '/v1/ping', 'HEAD');
+  const operation = {
+    options,
+    requestType: 'invalid-request-type'
+  };
+
+  assert.throws(
+    () => requester.startRequest(operation),
+    /unknown request type invalid-request-type/
+  );
+  assert.strictEqual(options.headers['ML-Agent-ID'], expectedHeader);
+
+  client.release();
+}
+
+describe('telemetry header runtime validation', function() {
+  it('includes ML-Agent-ID by default', function() {
+    verifyTelemetryHeader(
+      {
+        host: 'localhost',
+        port: 8000,
+        user: 'admin',
+        password: 'admin',
+        authType: 'digest'
+      },
+      'nodejs'
+    );
+  });
+
+  it('omits ML-Agent-ID when disableTelemetryHeader is true', function() {
+    verifyTelemetryHeader(
+      {
+        host: 'localhost',
+        port: 8000,
+        user: 'admin',
+        password: 'admin',
+        authType: 'digest',
+        disableTelemetryHeader: true
+      },
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
### Summary
This PR documents the ML-Agent-ID telemetry header behavior and adds an opt-out connection option so security-sensitive deployments can suppress that header when needed.
Default behavior is preserved: if no opt-out is provided, requests still include ML-Agent-ID: nodejs.

### What Changed

1. Added conditional telemetry header logic in requester.js: 
    - ML-Agent-ID is now added only when disableTelemetryHeader is not true.
2. Added disableTelemetryHeader to allowed connection parameters in marklogic.js.
3. Documented the new connection option in createDatabaseClient JSDoc in marklogic.js.
4. Added TypeScript typing for disableTelemetryHeader in marklogic.d.ts.
5. Added README documentation for:
   - default telemetry header behavior,
   - what it discloses,
   - and how to opt out with disableTelemetryHeader in README.md.
6. Added tests for both behaviors:
   - JS unit test: header present by default and omitted when disabled in telemetry-header-test.js
   - TS runtime smoke test with the same assertions in telemetry-header-runtime.test.ts
   - TS compile-time coverage for new config option in basic-types.test.ts:58

### Why This Approach

1. Minimal surface-area change:
   - only gates a single header write,
   - no auth flow or request path behavior changes beyond the telemetry header.
2. Backward compatibility:
   - existing clients remain unchanged unless disableTelemetryHeader is explicitly set.
3. Clear security posture:
   - keeps telemetry by default for ecosystem consistency,
   - allows explicit opt-out for hardened environments.
4. Aligns with acceptance criteria:
   - implementation, docs, typings, and tests are all covered.

### Validation

1. Use Node 22 or higher.
2. Install dependencies: `npm install`
3. Run focused JavaScript test for header behavior: `npx mocha telemetry-header-test.js`
4. Compile TypeScript runtime tests: `npm run test:compile`
5. Run TypeScript runtime tests: `npm run test:typescript`

### Expected Results

1. test-basic telemetry test passes both cases:
   - Includes ML-Agent-ID by default
   - Omits ML-Agent-ID when disableTelemetryHeader is true
2. TypeScript compile completes with no errors.
3. TypeScript runtime suite executes successfully in Node 22+.
