### PR TITLE
MLE-32051 Fix multipart body termination for Node.js v26 compatibility

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -477,14 +477,14 @@ function multipartRequester(request) {
       },
       body: form,
     });
-    multipartStream.on('data', chunk => request.write(chunk));
-    multipartStream.on('end', () => request.end());
+    multipartStream.on('error', err => request.destroy(err));
+    multipartStream.pipe(request);
   } else if (typeof requestPartsProvider === 'function') {
     // requestPartsProvider path: use multipart-stream (provider controls parts)
     const multipartStream = new Multipart(boundary);
     requestPartsProvider.call(operation, multipartStream);
-    multipartStream.on('data', chunk => request.write(chunk));
-    multipartStream.on('end', () => request.end());
+    multipartStream.on('error', err => request.destroy(err));
+    multipartStream.pipe(request);
   } else {
     // requestPartList path: all parts have synchronous content — build body directly
     // as a Buffer to avoid sandwich-stream's 'readable' event regression on Node.js v26+.
@@ -513,7 +513,8 @@ function multipartRequester(request) {
       operation.logger.debug('no part list to write');
     }
     bufs.push(Buffer.from(CRNL + '--' + boundary + '--'));
-    request.end(Buffer.concat(bufs));
+    for (let i = 0; i < bufs.length - 1; i++) { request.write(bufs[i]); }
+    request.end(bufs[bufs.length - 1]);
   }
 }
 function chunkedRequester(request) {
@@ -572,7 +573,8 @@ function chunkedMultipartRequester(request) {
           if (written > 0) { request.write(Buffer.from(CRNL + '--' + boundary + CRNL)); }
           Object.entries(headers).forEach(([k, v]) => request.write(Buffer.from(k + ': ' + v + CRNL)));
           request.write(Buffer.from(CRNL));
-          requestWriter.on('data', chunk => request.write(chunk));
+          requestWriter.on('error', err => request.destroy(err));
+          requestWriter.pipe(request, { end: false });
           requestWriter.on('end', () => {
             request.write(Buffer.from(CRNL + '--' + boundary + '--'));
             request.end();

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -420,11 +420,13 @@ function multipartRequester(request) {
   const operation = this;
 
   const operationBoundary = operation.multipartBoundary;
-  const multipartStream = new Multipart((operationBoundary == null) ?
-        mlutil.multipartBoundary : operationBoundary);
+  const boundary = (operationBoundary == null) ? mlutil.multipartBoundary : operationBoundary;
+  const CRNL = '\r\n';
 
   const requestPartsProvider = operation.requestPartsProvider;
-  if(operation.bindingParam) {
+  if (operation.bindingParam) {
+    // bindingParam path: use multipart-stream (form-data body is a stream)
+    const multipartStream = new Multipart(boundary);
     const form = new formData();
     const bindingParam = operation.bindingParam;
     const query = bindingParam.query;
@@ -475,25 +477,34 @@ function multipartRequester(request) {
       },
       body: form,
     });
+    multipartStream.on('data', chunk => request.write(chunk));
+    multipartStream.on('end', () => request.end());
   } else if (typeof requestPartsProvider === 'function') {
+    // requestPartsProvider path: use multipart-stream (provider controls parts)
+    const multipartStream = new Multipart(boundary);
     requestPartsProvider.call(operation, multipartStream);
+    multipartStream.on('data', chunk => request.write(chunk));
+    multipartStream.on('end', () => request.end());
   } else {
+    // requestPartList path: all parts have synchronous content — build body directly
+    // as a Buffer to avoid sandwich-stream's 'readable' event regression on Node.js v26+.
     const parts = operation.requestPartList;
+    const bufs = [Buffer.from('--' + boundary + CRNL)];
+    let written = 0;
     if (Array.isArray(parts)) {
-      const partsLen = parts.length;
-      operation.logger.debug('writing %s parts', partsLen);
-      for (let i=0; i < partsLen; i++) {
+      operation.logger.debug('writing %s parts', parts.length);
+      for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
         const headers = part.headers;
         const content = part.content;
-        if ((headers != null) &&
-            (content != null)) {
+        if ((headers != null) && (content != null)) {
+          if (written > 0) bufs.push(Buffer.from(CRNL + '--' + boundary + CRNL));
           operation.logger.debug('starting part %s', i);
-          multipartStream.addPart({
-            headers: headers,
-            body:    content
-            });
+          Object.entries(headers).forEach(([k, v]) => bufs.push(Buffer.from(k + ': ' + v + CRNL)));
+          bufs.push(Buffer.from(CRNL));
+          bufs.push(Buffer.isBuffer(content) ? content : Buffer.from(content));
           operation.logger.debug('finished part %s', i);
+          written++;
         } else {
           operation.logger.debug('nothing to write for part %d', i);
         }
@@ -501,8 +512,9 @@ function multipartRequester(request) {
     } else {
       operation.logger.debug('no part list to write');
     }
+    bufs.push(Buffer.from(CRNL + '--' + boundary + '--'));
+    request.end(Buffer.concat(bufs));
   }
-  multipartStream.pipe(request);
 }
 function chunkedRequester(request) {
   /*jshint validthis:true */
@@ -530,38 +542,47 @@ function chunkedMultipartRequester(request) {
     request.end();
   } else {
     const operationBoundary = operation.multipartBoundary;
+    const boundary = (operationBoundary == null) ? mlutil.multipartBoundary : operationBoundary;
+    const CRNL = '\r\n';
 
-    const multipartStream = new Multipart((operationBoundary == null) ?
-        mlutil.multipartBoundary : operationBoundary);
-
+    // Write all non-stream (metadata) parts directly as Buffers, then pipe the
+    // streaming content part into the request. This avoids the sandwich-stream
+    // 'readable' event regression on Node.js v26+ where multi-chunk PassThrough
+    // streams are not fully drained, leaving the closing boundary unemitted.
     const partLast = requestDocument.length - 1;
+    request.write(Buffer.from('--' + boundary + CRNL));
+    let written = 0;
     for (let i=0; i <= partLast; i++) {
       const part = requestDocument[i];
       const headers = part.headers;
       if (i < partLast) {
         const content = part.content;
-        if ((headers != null) &&
-            (content != null)) {
-          multipartStream.addPart({
-            headers: headers,
-            body:    mlutil.marshal(content, operation)
-            });
+        if ((headers != null) && (content != null)) {
+          if (written > 0) request.write(Buffer.from(CRNL + '--' + boundary + CRNL));
+          Object.entries(headers).forEach(([k, v]) => request.write(Buffer.from(k + ': ' + v + CRNL)));
+          request.write(Buffer.from(CRNL));
+          const marshaledContent = mlutil.marshal(content, operation);
+          request.write(Buffer.isBuffer(marshaledContent) ? marshaledContent : Buffer.from(marshaledContent));
+          written++;
         } else {
           operation.logger.debug('could not write metadata part');
         }
       } else {
         if (headers != null) {
-          multipartStream.addPart({
-            headers: headers,
-            body:    requestWriter
-            });
+          if (written > 0) request.write(Buffer.from(CRNL + '--' + boundary + CRNL));
+          Object.entries(headers).forEach(([k, v]) => request.write(Buffer.from(k + ': ' + v + CRNL)));
+          request.write(Buffer.from(CRNL));
+          requestWriter.on('data', chunk => request.write(chunk));
+          requestWriter.on('end', () => {
+            request.write(Buffer.from(CRNL + '--' + boundary + '--'));
+            request.end();
+          });
         } else {
           operation.logger.debug('could not write content part');
+          request.end();
         }
       }
     }
-
-    multipartStream.pipe(request);
   }
 }
 

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -498,7 +498,7 @@ function multipartRequester(request) {
         const headers = part.headers;
         const content = part.content;
         if ((headers != null) && (content != null)) {
-          if (written > 0) bufs.push(Buffer.from(CRNL + '--' + boundary + CRNL));
+          if (written > 0) { bufs.push(Buffer.from(CRNL + '--' + boundary + CRNL)); }
           operation.logger.debug('starting part %s', i);
           Object.entries(headers).forEach(([k, v]) => bufs.push(Buffer.from(k + ': ' + v + CRNL)));
           bufs.push(Buffer.from(CRNL));
@@ -558,7 +558,7 @@ function chunkedMultipartRequester(request) {
       if (i < partLast) {
         const content = part.content;
         if ((headers != null) && (content != null)) {
-          if (written > 0) request.write(Buffer.from(CRNL + '--' + boundary + CRNL));
+          if (written > 0) { request.write(Buffer.from(CRNL + '--' + boundary + CRNL)); }
           Object.entries(headers).forEach(([k, v]) => request.write(Buffer.from(k + ': ' + v + CRNL)));
           request.write(Buffer.from(CRNL));
           const marshaledContent = mlutil.marshal(content, operation);
@@ -569,7 +569,7 @@ function chunkedMultipartRequester(request) {
         }
       } else {
         if (headers != null) {
-          if (written > 0) request.write(Buffer.from(CRNL + '--' + boundary + CRNL));
+          if (written > 0) { request.write(Buffer.from(CRNL + '--' + boundary + CRNL)); }
           Object.entries(headers).forEach(([k, v]) => request.write(Buffer.from(k + ': ' + v + CRNL)));
           request.write(Buffer.from(CRNL));
           requestWriter.on('data', chunk => request.write(chunk));

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -486,35 +486,60 @@ function multipartRequester(request) {
     multipartStream.on('error', err => request.destroy(err));
     multipartStream.pipe(request);
   } else {
-    // requestPartList path: all parts have synchronous content — build body directly
-    // as a Buffer to avoid sandwich-stream's 'readable' event regression on Node.js v26+.
     const parts = operation.requestPartList;
-    const bufs = [Buffer.from('--' + boundary + CRNL)];
-    let written = 0;
-    if (Array.isArray(parts)) {
+    // Stream-driven PassThroughs receive writes asynchronously (after listeners are
+    // attached), so multipart-stream works correctly for them on all Node.js versions.
+    // Only the all-synchronous case triggers the Node.js v26+ 'readable' regression.
+    const hasStreamContent = Array.isArray(parts) &&
+        parts.some(p => p.content !== null && typeof p.content.pipe === 'function');
+
+    if (hasStreamContent) {
+      const multipartStream = new Multipart(boundary);
       operation.logger.debug('writing %s parts', parts.length);
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
         const headers = part.headers;
         const content = part.content;
-        if ((headers != null) && (content != null)) {
-          if (written > 0) { bufs.push(Buffer.from(CRNL + '--' + boundary + CRNL)); }
+        if ((headers !== null) && (content !== null)) {
           operation.logger.debug('starting part %s', i);
-          Object.entries(headers).forEach(([k, v]) => bufs.push(Buffer.from(k + ': ' + v + CRNL)));
-          bufs.push(Buffer.from(CRNL));
-          bufs.push(Buffer.isBuffer(content) ? content : Buffer.from(content));
+          multipartStream.addPart({ headers: headers, body: content });
           operation.logger.debug('finished part %s', i);
-          written++;
         } else {
           operation.logger.debug('nothing to write for part %d', i);
         }
       }
+      multipartStream.on('error', err => request.destroy(err));
+      multipartStream.pipe(request);
     } else {
-      operation.logger.debug('no part list to write');
+      // All synchronous content: build body directly as Buffers to avoid
+      // sandwich-stream's 'readable' event regression on Node.js v26+.
+      const bufs = [Buffer.from('--' + boundary + CRNL)];
+      let written = 0;
+      if (Array.isArray(parts)) {
+        operation.logger.debug('writing %s parts', parts.length);
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
+          const headers = part.headers;
+          const content = part.content;
+          if ((headers != null) && (content != null)) {
+            if (written > 0) { bufs.push(Buffer.from(CRNL + '--' + boundary + CRNL)); }
+            operation.logger.debug('starting part %s', i);
+            Object.entries(headers).forEach(([k, v]) => bufs.push(Buffer.from(k + ': ' + v + CRNL)));
+            bufs.push(Buffer.from(CRNL));
+            bufs.push(Buffer.isBuffer(content) ? content : Buffer.from(content));
+            operation.logger.debug('finished part %s', i);
+            written++;
+          } else {
+            operation.logger.debug('nothing to write for part %d', i);
+          }
+        }
+      } else {
+        operation.logger.debug('no part list to write');
+      }
+      bufs.push(Buffer.from(CRNL + '--' + boundary + '--'));
+      for (let i = 0; i < bufs.length - 1; i++) { request.write(bufs[i]); }
+      request.end(bufs[bufs.length - 1]);
     }
-    bufs.push(Buffer.from(CRNL + '--' + boundary + '--'));
-    for (let i = 0; i < bufs.length - 1; i++) { request.write(bufs[i]); }
-    request.end(bufs[bufs.length - 1]);
   }
 }
 function chunkedRequester(request) {


### PR DESCRIPTION
## Summary

Fixes `client.documents.write()` failing with `ECONNRESET` / socket hang-up when writing an array of documents on Node.js v26.x.

Closes [GH #1104](https://github.com/marklogic/node-client-api/issues/1104) | Jira: [MLE-32051](https://progresssoftware.atlassian.net/browse/MLE-32051)

---

## Problem

When calling `client.documents.write([doc1, doc2, ...])` on Node.js v26, the HTTP request body is never properly terminated. MarkLogic receives the part content but not the closing multipart boundary (`--boundary--`), and responds with:

```
HTTP 500: XDMP-MULTIPART-BOUNDARY: xdmp:get-request-part-body("json")
         -- Ending of the boundary is incorrect
```

The client then receives an `ECONNRESET` after ~30 seconds.

**Root cause:** `multipart-stream` 2.0.1 uses `sandwich-stream` (a `Readable`) to assemble the multipart body. For each part it creates a `PassThrough` stream, writes headers + CRNL + body content as separate `.write()` calls, and adds it to `sandwich-stream`. `sandwich-stream`'s `_currentStreamOnReadable` calls `read()` to pull data from each sub-stream. On Node.js v26, `read()` returns only the **first write-chunk** from a PassThrough; the `'readable'` event does not re-fire for subsequent chunks, leaving them stranded. Because `_currentStreamOnEnd` never triggers, `sandwich-stream`'s `_pushTail()` / `push(null)` is never reached and the closing boundary is never emitted.

The bug affects **Node.js v26.6.0** (the reporter's version) and **v26.7.0**. Node.js v24.x is not affected.

---

## Fix

requester.js — bypasses `sandwich-stream` in both affected code paths:

- **`multipartRequester()` — `requestPartList` path** (`client.documents.write(array)`): detects whether any part carries stream content (`typeof content.pipe === 'function'`).
  - **All-synchronous content** (the v26 bug scenario — array of document objects): the multipart body is assembled directly as incremental `Buffer` writes to the request, avoiding `sandwich-stream` entirely.
  - **Stream content present** (binary writes, large documents, Data Services `ValueStream`): falls back to `multipart-stream` with `pipe()`. Stream-driven PassThroughs receive writes asynchronously after listeners are attached, so the Node.js v26 `'readable'` regression does not affect them.
- **`chunkedMultipartRequester()`**: non-stream (metadata) parts are written to the request as `Buffer` chunks; the final streaming content part is forwarded via `requestWriter.pipe(request, { end: false })` followed by the closing boundary and `request.end()`.

The `bindingParam` and `requestPartsProvider` paths in `multipartRequester()` retain `multipart-stream` with `pipe()` and an explicit `err => request.destroy(err)` error handler to properly tear down the socket on stream errors. 

---

## Testing

Tested manually with `repro.mjs` (see MLE-32051):

| Node.js | Before fix | After fix |
|---------|-----------|-----------|
| v24.19.0 | PASS | PASS |
| v26.6.0 | **FAIL** (ECONNRESET after 30s) | PASS (0.39s) |
| v26.7.0 | **FAIL** (ECONNRESET after 30s) | PASS (0.70s) |

MarkLogic server: `marklogic-server-ubi:11.3.6-ubi-2.2.6` 

Existing tests continue to pass with: `npx mocha test-basic/documents-core.js --timeout 0


[MLE-32051]: https://progresssoftware.atlassian.net/browse/MLE-32051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ